### PR TITLE
Migrate Course CRUD

### DIFF
--- a/src/main/java/teammates/common/datatransfer/sqlattributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/sqlattributes/CourseAttributes.java
@@ -32,7 +32,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         this.id = courseId;
         this.timeZone = Const.DEFAULT_TIME_ZONE;
         this.institute = Const.UNKNOWN_INSTITUTION;
-        this.createdAt = Instant.now();
+        this.createdAt = null;
         this.deletedAt = null;
     }
 
@@ -56,9 +56,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         courseAttributes.timeZone = courseTimeZone;
         courseAttributes.institute = course.getInstitute();
 
-        if (course.getCreatedAt() != null) {
-            courseAttributes.createdAt = course.getCreatedAt();
-        }
+        courseAttributes.createdAt = course.getCreatedAt();
         courseAttributes.deletedAt = course.getDeletedAt();
 
         return courseAttributes;
@@ -131,7 +129,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     @Override
     public Course toEntity() {
-        return new Course(getId(), getName(), getTimeZone(), getInstitute(), createdAt, deletedAt);
+        return new Course(getId(), getName(), getTimeZone(), getInstitute(), deletedAt);
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/sqlattributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/sqlattributes/CourseAttributes.java
@@ -189,10 +189,10 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     }
 
     /**
-     * Returns a {@link Builder} to build {@link UpdateOptions} for a course.
+     * Returns a {@link UpdateOptions.Builder} to build {@link UpdateOptions} for a course.
      */
-    public static Builder updateOptionsBuilder(String courseId) {
-        return new Builder(courseId);
+    public static UpdateOptions.Builder updateOptionsBuilder(String courseId) {
+        return new UpdateOptions.Builder(courseId);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/LogicNew.java
+++ b/src/main/java/teammates/logic/api/LogicNew.java
@@ -69,4 +69,17 @@ public class LogicNew {
         return coursesLogic.updateCourseCascade(updateOptions);
     }
 
+    /**
+     * Deletes a course cascade its students, instructors, sessions, responses, deadline extensions and comments.
+     *
+     * <p>Fails silently if no such course.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     */
+    public void deleteCourseCascade(String courseId) {
+        assert courseId != null;
+        coursesLogic.deleteCourseCascade(courseId);
+    }
+
 }

--- a/src/main/java/teammates/logic/api/LogicNew.java
+++ b/src/main/java/teammates/logic/api/LogicNew.java
@@ -2,6 +2,7 @@ package teammates.logic.api;
 
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.logic.sql.CoursesLogic;
 
@@ -47,6 +48,25 @@ public class LogicNew {
         assert courseId != null;
 
         return coursesLogic.getCourse(courseId);
+    }
+
+    /**
+     * Updates a course by {@link CourseAttributes.UpdateOptions}.
+     *
+     * <p>If the {@code timezone} of the course is changed, cascade the change to its corresponding feedback sessions.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return updated course
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the course cannot be found
+     */
+    public CourseAttributes updateCourseCascade(CourseAttributes.UpdateOptions updateOptions)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        return coursesLogic.updateCourseCascade(updateOptions);
     }
 
 }

--- a/src/main/java/teammates/logic/api/LogicNew.java
+++ b/src/main/java/teammates/logic/api/LogicNew.java
@@ -1,5 +1,7 @@
 package teammates.logic.api;
 
+import java.time.Instant;
+
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -80,6 +82,32 @@ public class LogicNew {
     public void deleteCourseCascade(String courseId) {
         assert courseId != null;
         coursesLogic.deleteCourseCascade(courseId);
+    }
+
+    /**
+     * Moves a course to Recycle Bin by its given corresponding ID.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return the deletion timestamp assigned to the course.
+     */
+    public Instant moveCourseToRecycleBin(String courseId) throws EntityDoesNotExistException {
+        assert courseId != null;
+        return coursesLogic.moveCourseToRecycleBin(courseId);
+    }
+
+    /**
+     * Restores a course and all data related to the course from Recycle Bin by
+     * its given corresponding ID.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     */
+    public void restoreCourseFromRecycleBin(String courseId) throws EntityDoesNotExistException {
+        assert courseId != null;
+
+        coursesLogic.restoreCourseFromRecycleBin(courseId);
     }
 
 }

--- a/src/main/java/teammates/logic/sql/CoursesLogic.java
+++ b/src/main/java/teammates/logic/sql/CoursesLogic.java
@@ -2,6 +2,7 @@ package teammates.logic.sql;
 
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sql.CoursesDb;
 
@@ -42,6 +43,27 @@ public final class CoursesLogic {
      */
     public CourseAttributes getCourse(String courseId) {
         return coursesDb.getCourse(courseId);
+    }
+
+    /**
+     * Updates a course by {@link CourseAttributes.UpdateOptions}.
+     *
+     * <p>If the {@code timezone} of the course is changed, cascade the change to its corresponding feedback sessions.
+     *
+     * @return updated course
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the course cannot be found
+     */
+    public CourseAttributes updateCourseCascade(CourseAttributes.UpdateOptions updateOptions)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        CourseAttributes oldCourse = coursesDb.getCourse(updateOptions.getCourseId());
+        CourseAttributes updatedCourse = coursesDb.updateCourse(updateOptions);
+
+        if (!updatedCourse.getTimeZone().equals(oldCourse.getTimeZone())) {
+            // TODO: Cascade update to feedback sessions once feedback sessions are migrated
+        }
+
+        return updatedCourse;
     }
 
 }

--- a/src/main/java/teammates/logic/sql/CoursesLogic.java
+++ b/src/main/java/teammates/logic/sql/CoursesLogic.java
@@ -66,5 +66,19 @@ public final class CoursesLogic {
         return updatedCourse;
     }
 
+    /**
+     * Deletes a course cascade its students, instructors, sessions, responses, deadline extensions and comments.
+     *
+     * <p>Fails silently if no such course.
+     */
+    public void deleteCourseCascade(String courseId) {
+        if (getCourse(courseId) == null) {
+            return;
+        }
+
+        // TODO: Handle cascading
+        coursesDb.deleteCourse(courseId);
+    }
+
 }
 

--- a/src/main/java/teammates/logic/sql/CoursesLogic.java
+++ b/src/main/java/teammates/logic/sql/CoursesLogic.java
@@ -1,5 +1,7 @@
 package teammates.logic.sql;
 
+import java.time.Instant;
+
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -78,6 +80,21 @@ public final class CoursesLogic {
 
         // TODO: Handle cascading
         coursesDb.deleteCourse(courseId);
+    }
+
+    /**
+     * Moves a course to Recycle Bin by its given corresponding ID.
+     * @return the time when the course is moved to the recycle bin
+     */
+    public Instant moveCourseToRecycleBin(String courseId) throws EntityDoesNotExistException {
+        return coursesDb.softDeleteCourse(courseId);
+    }
+
+    /**
+     * Restores a course from Recycle Bin by its given corresponding ID.
+     */
+    public void restoreCourseFromRecycleBin(String courseId) throws EntityDoesNotExistException {
+        coursesDb.restoreDeletedCourse(courseId);
     }
 
 }

--- a/src/main/java/teammates/storage/sql/CoursesDb.java
+++ b/src/main/java/teammates/storage/sql/CoursesDb.java
@@ -1,5 +1,7 @@
 package teammates.storage.sql;
 
+import java.time.Instant;
+
 import org.hibernate.Session;
 
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
@@ -94,6 +96,39 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
         Course course = getCourseEntity(courseId);
 
         deleteEntity(course);
+    }
+
+    /**
+     * Soft-deletes a course by its given corresponding ID.
+     * @return Soft-deletion time of the course.
+     */
+    public Instant softDeleteCourse(String courseId) throws EntityDoesNotExistException {
+        assert courseId != null;
+        Course courseEntity = getCourseEntity(courseId);
+
+        if (courseEntity == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
+        }
+
+        courseEntity.setDeletedAt(Instant.now());
+        saveEntity(courseEntity);
+
+        return courseEntity.getDeletedAt();
+    }
+
+    /**
+     * Restores a soft-deleted course by its given corresponding ID.
+     */
+    public void restoreDeletedCourse(String courseId) throws EntityDoesNotExistException {
+        assert courseId != null;
+        Course courseEntity = getCourseEntity(courseId);
+
+        if (courseEntity == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
+        }
+
+        courseEntity.setDeletedAt(null);
+        saveEntity(courseEntity);
     }
 
     @Override

--- a/src/main/java/teammates/storage/sql/CoursesDb.java
+++ b/src/main/java/teammates/storage/sql/CoursesDb.java
@@ -3,6 +3,8 @@ package teammates.storage.sql;
 import org.hibernate.Session;
 
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Course;
 
@@ -37,6 +39,50 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
         assert courseId != null;
 
         return makeAttributesOrNull(getCourseEntity(courseId));
+    }
+
+    /**
+     * Updates a course by {@link CourseAttributes.UpdateOptions}.
+     *
+     * @return updated course
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the course cannot be found
+     */
+    public CourseAttributes updateCourse(CourseAttributes.UpdateOptions updateOptions)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        Course course = getCourseEntity(updateOptions.getCourseId());
+
+        if (course == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
+        }
+
+        CourseAttributes newAttributes = makeAttributes(course);
+        newAttributes.update(updateOptions);
+
+        newAttributes.sanitizeForSaving();
+        if (!newAttributes.isValid()) {
+            throw new InvalidParametersException(newAttributes.getInvalidityInfo());
+        }
+
+        // update only if change
+        boolean hasSameAttributes =
+                this.hasSameValue(course.getName(), newAttributes.getName())
+                        && this.hasSameValue(course.getInstitute(), newAttributes.getInstitute())
+                        && this.hasSameValue(course.getTimeZone(), newAttributes.getTimeZone());
+        if (hasSameAttributes) {
+            log.info(String.format(OPTIMIZED_SAVING_POLICY_APPLIED, Course.class.getSimpleName(), updateOptions));
+            return newAttributes;
+        }
+
+        course.setName(newAttributes.getName());
+        course.setTimeZone(newAttributes.getTimeZone());
+        course.setInstitute(newAttributes.getInstitute());
+
+        saveEntity(course);
+
+        return makeAttributes(course);
     }
 
     @Override

--- a/src/main/java/teammates/storage/sql/CoursesDb.java
+++ b/src/main/java/teammates/storage/sql/CoursesDb.java
@@ -85,6 +85,17 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
         return makeAttributes(course);
     }
 
+    /**
+     * Deletes a course.
+     */
+    public void deleteCourse(String courseId) {
+        assert courseId != null;
+
+        Course course = getCourseEntity(courseId);
+
+        deleteEntity(course);
+    }
+
     @Override
     CourseAttributes makeAttributes(Course entity) {
         assert entity != null;

--- a/src/main/java/teammates/storage/sql/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sql/EntitiesDb.java
@@ -95,6 +95,32 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
     abstract boolean hasExistingEntities(A entityToCreate);
 
     /**
+     * Checks whether two values are the same.
+     */
+    <T> boolean hasSameValue(T oldValue, T newValue) {
+        return oldValue.equals(newValue);
+    }
+
+    /**
+     * Saves an entity.
+     */
+    void saveEntity(E entityToSave) {
+        assert entityToSave != null;
+
+        Transaction tx = null;
+
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            tx = session.beginTransaction();
+            session.merge(entityToSave);
+            tx.commit();
+            log.info("Entity saved: " + JsonUtils.toJson(entityToSave));
+        } catch (HibernateException e) {
+            // TODO: Handle errors
+            tx.rollback();
+        }
+    }
+
+    /**
      * Converts from entity to attributes.
      */
     abstract A makeAttributes(E entity);

--- a/src/main/java/teammates/storage/sql/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sql/EntitiesDb.java
@@ -1,9 +1,5 @@
 package teammates.storage.sql;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -25,7 +21,7 @@ import teammates.storage.sqlentity.BaseEntity;
 abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
 
     /**
-     * Error message when trying to create entity that already exist.
+     * Error message when trying to create entity that already exists.
      */
     static final String ERROR_CREATE_ENTITY_ALREADY_EXISTS = "Trying to create an entity that exists: %s";
 
@@ -64,7 +60,7 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
         }
 
         if (shouldCheckExistence && hasExistingEntities(entityToAdd)) {
-            String error = String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, entityToAdd.toString());
+            String error = String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, entityToAdd);
             throw new EntityAlreadyExistsException(error);
         }
 
@@ -121,20 +117,27 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
     }
 
     /**
+     * Deletes an entity.
+     */
+    void deleteEntity(E entityToDelete) {
+        assert entityToDelete != null;
+
+        Transaction tx = null;
+
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            tx = session.beginTransaction();
+            session.remove(entityToDelete);
+            tx.commit();
+        } catch (HibernateException e) {
+            // TODO: Handle errors
+            tx.rollback();
+        }
+    }
+
+    /**
      * Converts from entity to attributes.
      */
     abstract A makeAttributes(E entity);
-
-    /**
-     * Converts a collection of entities to a list of attributes.
-     */
-    List<A> makeAttributes(Collection<E> entities) {
-        List<A> attributes = new LinkedList<>();
-        for (E entity : entities) {
-            attributes.add(makeAttributes(entity));
-        }
-        return attributes;
-    }
 
     /**
      * Converts from entity to attributes.

--- a/src/main/java/teammates/storage/sqlentity/Course.java
+++ b/src/main/java/teammates/storage/sqlentity/Course.java
@@ -2,19 +2,19 @@ package teammates.storage.sqlentity;
 
 import java.time.Instant;
 
-import teammates.common.util.Const;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 
 /**
  * Represents a course entity.
  */
 @Entity
-@Table(name = "courses", uniqueConstraints = { @UniqueConstraint(columnNames = "id") })
+@Table(name = "courses")
 public class Course extends BaseEntity {
 
     @Id
@@ -30,9 +30,11 @@ public class Course extends BaseEntity {
     @Column(name = "institute", nullable = false)
     private String institute;
 
+    @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
+    @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -43,23 +45,14 @@ public class Course extends BaseEntity {
         // recommended by Hibernate
     }
 
-    public Course(String courseId, String courseName, String courseTimeZone, String institute,
-            Instant createdAt, Instant deletedAt) {
+    public Course(String courseId, String courseName, String courseTimeZone, String institute, Instant deletedAt) {
         this.setUniqueId(courseId);
         this.setName(courseName);
-        if (courseTimeZone == null) {
-            this.setTimeZone(Const.DEFAULT_TIME_ZONE);
-        } else {
-            this.setTimeZone(courseTimeZone);
-        }
+        this.setTimeZone(courseTimeZone);
         this.setInstitute(institute);
-        if (createdAt == null) {
-            this.setCreatedAt(Instant.now());
-        } else {
-            this.setCreatedAt(createdAt);
+        if (deletedAt != null) {
+            this.setDeletedAt(deletedAt);
         }
-        this.setUpdatedAt(this.createdAt);
-        this.setDeletedAt(deletedAt);
     }
 
     public String getUniqueId() {

--- a/src/main/java/teammates/ui/output/CourseData.java
+++ b/src/main/java/teammates/ui/output/CourseData.java
@@ -29,6 +29,7 @@ public class CourseData extends ApiOutput {
             this.deletionTimestamp = courseAttributes.getDeletedAt().toEpochMilli();
         }
     }
+
     public CourseData(teammates.common.datatransfer.sqlattributes.CourseAttributes courseAttributes) {
         this.courseId = courseAttributes.getId();
         this.courseName = courseAttributes.getName();

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -33,6 +33,11 @@ class BinCourseAction extends Action {
             CourseAttributes courseAttributes = logic.getCourse(idOfCourseToBin);
             courseAttributes.setDeletedAt(logic.moveCourseToRecycleBin(idOfCourseToBin));
 
+            // If course is found in SQL database, bin said course as well
+            if (logicNew.getCourse(idOfCourseToBin) != null) {
+                logicNew.moveCourseToRecycleBin(idOfCourseToBin);
+            }
+
             return new JsonResult(new CourseData(courseAttributes));
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -29,6 +29,7 @@ class DeleteCourseAction extends Action {
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         logic.deleteCourseCascade(idOfCourseToDelete);
+        logicNew.deleteCourseCascade(idOfCourseToDelete);
 
         return new JsonResult(new MessageOutput("OK"));
     }

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -33,6 +33,11 @@ class RestoreCourseAction extends Action {
         try {
             logic.restoreCourseFromRecycleBin(idOfCourseToRestore);
 
+            // If course is found in SQL database, bin said course as well
+            if (logicNew.getCourse(idOfCourseToRestore) != null) {
+                logicNew.restoreCourseFromRecycleBin(idOfCourseToRestore);
+            }
+
             statusMessage = "The course " + idOfCourseToRestore + " has been restored.";
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -44,11 +44,16 @@ class UpdateCourseAction extends Action {
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String courseName = courseUpdateRequest.getCourseName();
-        CourseAttributes updatedCourse;
+        teammates.common.datatransfer.sqlattributes.CourseAttributes updatedCourse;
 
         try {
-            updatedCourse = logic.updateCourseCascade(
+            logic.updateCourseCascade(
                     CourseAttributes.updateOptionsBuilder(courseId)
+                            .withName(courseName)
+                            .withTimezone(courseTimeZone)
+                            .build());
+            updatedCourse = logicNew.updateCourseCascade(
+                    teammates.common.datatransfer.sqlattributes.CourseAttributes.updateOptionsBuilder(courseId)
                             .withName(courseName)
                             .withTimezone(courseTimeZone)
                             .build());

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -54,9 +54,7 @@ class UpdateCourseAction extends Action {
                             .build());
 
             // If course is found in SQL database, update said course as well
-            teammates.common.datatransfer.sqlattributes.CourseAttributes sqlCourseAttributes
-                    = logicNew.getCourse(courseId);
-            if (sqlCourseAttributes != null) {
+            if (logicNew.getCourse(courseId) != null) {
                 logicNew.updateCourseCascade(
                         teammates.common.datatransfer.sqlattributes.CourseAttributes.updateOptionsBuilder(courseId)
                                 .withName(courseName)

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -44,19 +44,25 @@ class UpdateCourseAction extends Action {
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String courseName = courseUpdateRequest.getCourseName();
-        teammates.common.datatransfer.sqlattributes.CourseAttributes updatedCourse;
+        CourseAttributes updatedCourse;
 
         try {
-            logic.updateCourseCascade(
+            updatedCourse = logic.updateCourseCascade(
                     CourseAttributes.updateOptionsBuilder(courseId)
                             .withName(courseName)
                             .withTimezone(courseTimeZone)
                             .build());
-            updatedCourse = logicNew.updateCourseCascade(
-                    teammates.common.datatransfer.sqlattributes.CourseAttributes.updateOptionsBuilder(courseId)
-                            .withName(courseName)
-                            .withTimezone(courseTimeZone)
-                            .build());
+
+            // If course is found in SQL database, update said course as well
+            teammates.common.datatransfer.sqlattributes.CourseAttributes sqlCourseAttributes
+                    = logicNew.getCourse(courseId);
+            if (sqlCourseAttributes != null) {
+                logicNew.updateCourseCascade(
+                        teammates.common.datatransfer.sqlattributes.CourseAttributes.updateOptionsBuilder(courseId)
+                                .withName(courseName)
+                                .withTimezone(courseTimeZone)
+                                .build());
+            }
         } catch (InvalidParametersException ipe) {
             throw new InvalidHttpRequestBodyException(ipe);
         } catch (EntityDoesNotExistException edee) {


### PR DESCRIPTION
Fixes #13.

Migrated course update, bin, restore and delete. Also added back course creation on Datastore side so that create/update/delete is done concurrently on both Datastore and SQL side for now.

Notable change: Used the `@CreationTimestamp` and `@UpdateTimestamp` annotations to let Hibernate handle the updating of createdAt and updatedAt attributes. This can be used for all other entities to migrate moving forward.
