### PR TITLE
[#15] Implement CRUD on Instructors table

### DIFF
--- a/src/main/java/teammates/logic/api/LogicNew.java
+++ b/src/main/java/teammates/logic/api/LogicNew.java
@@ -1,12 +1,16 @@
 package teammates.logic.api;
 
 import java.time.Instant;
+import java.util.List;
 
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
+import teammates.common.datatransfer.sqlattributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.logic.sql.CoursesLogic;
+import teammates.logic.sql.InstructorsLogic;
 
 /**
  * Provides the business logic for production usage of the system.
@@ -17,6 +21,7 @@ public class LogicNew {
 
     private static final LogicNew instance = new LogicNew();
 
+    final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
     final CoursesLogic coursesLogic = CoursesLogic.inst();
 
     LogicNew() {
@@ -25,6 +30,162 @@ public class LogicNew {
 
     public static LogicNew inst() {
         return instance;
+    }
+
+    /**
+     * Creates an instructor.
+     *
+     * <p>Preconditions:</p>
+     * * All parameters are non-null.
+     *
+     * @return the created instructor
+     * @throws InvalidParametersException if the instructor is not valid
+     * @throws EntityAlreadyExistsException if the instructor already exists in the database
+     */
+    public InstructorAttributes createInstructor(InstructorAttributes instructor)
+            throws InvalidParametersException, EntityAlreadyExistsException {
+        assert instructor != null;
+
+        return instructorsLogic.createInstructor(instructor);
+    }
+
+    /**
+     * Update instructor being edited to ensure validity of instructors for the course.
+     *
+     * @see InstructorsLogic#updateToEnsureValidityOfInstructorsForTheCourse(String, InstructorAttributes)
+     */
+    public void updateToEnsureValidityOfInstructorsForTheCourse(String courseId, InstructorAttributes instructorToEdit) {
+
+        assert courseId != null;
+        assert instructorToEdit != null;
+
+        instructorsLogic.updateToEnsureValidityOfInstructorsForTheCourse(courseId, instructorToEdit);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return null if not found.
+     */
+    public InstructorAttributes getInstructorForEmail(String courseId, String email) {
+
+        assert courseId != null;
+        assert email != null;
+
+        return instructorsLogic.getInstructorForEmail(courseId, email);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return null if not found.
+     */
+    public InstructorAttributes getInstructorForAccountId(String courseId, String accountId) {
+
+        assert accountId != null;
+        assert courseId != null;
+
+        return instructorsLogic.getInstructorForAccountId(courseId, accountId);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return null if not found.
+     */
+    public InstructorAttributes getInstructorForRegistrationKey(String registrationKey) {
+
+        assert registrationKey != null;
+
+        return instructorsLogic.getInstructorForRegistrationKey(registrationKey);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return Empty list if none found.
+     */
+    public List<InstructorAttributes> getInstructorsForAccountId(String accountId) {
+
+        assert accountId != null;
+
+        return instructorsLogic.getInstructorsForAccountId(accountId);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return Empty list if none found.
+     */
+    public List<InstructorAttributes> getInstructorsForAccountId(String accountId, boolean omitArchived) {
+
+        assert accountId != null;
+
+        return instructorsLogic.getInstructorsForAccountId(accountId, omitArchived);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return Empty list if none found.
+     */
+    public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
+
+        assert courseId != null;
+
+        return instructorsLogic.getInstructorsForCourse(courseId);
+    }
+
+    /**
+     * Updates an instructor by {@link InstructorAttributes.UpdateOptionsWithAccountId}.
+     *
+     * <p>Cascade update the comments, responses and deadline extensions associated with the instructor.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return updated instructor
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the instructor cannot be found
+     */
+    public InstructorAttributes updateInstructorCascade(InstructorAttributes.UpdateOptionsWithAccountId updateOptions)
+            throws InstructorUpdateException, InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        return instructorsLogic.updateInstructorByAccountIdCascade(updateOptions);
+    }
+
+    /**
+     * Updates an instructor by {@link InstructorAttributes.UpdateOptionsWithEmail}.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return updated instructor
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the instructor cannot be found
+     */
+    public InstructorAttributes updateInstructor(InstructorAttributes.UpdateOptionsWithEmail updateOptions)
+            throws InstructorUpdateException, InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        return instructorsLogic.updateInstructorByEmail(updateOptions);
+    }
+
+    /**
+     * Deletes an instructor cascade its associated feedback responses, deadline extensions and comments.
+     *
+     * <p>Fails silently if the student does not exist.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     */
+    public void deleteInstructorCascade(String courseId, String email) {
+
+        assert courseId != null;
+        assert email != null;
+
+        instructorsLogic.deleteInstructorCascade(courseId, email);
     }
 
     /**
@@ -52,6 +213,13 @@ public class LogicNew {
         assert courseId != null;
 
         return coursesLogic.getCourse(courseId);
+    }
+
+    /**
+     * Gets the institute associated with the course.
+     */
+    public String getCourseInstitute(String courseId) {
+        return coursesLogic.getCourseInstitute(courseId);
     }
 
     /**

--- a/src/main/java/teammates/logic/sql/CoursesLogic.java
+++ b/src/main/java/teammates/logic/sql/CoursesLogic.java
@@ -43,6 +43,15 @@ public final class CoursesLogic {
     }
 
     /**
+     * Gets the institute associated with the course.
+     */
+    public String getCourseInstitute(String courseId) {
+        CourseAttributes cd = getCourse(courseId);
+        assert cd != null : "Trying to getCourseInstitute for inexistent course with id " + courseId;
+        return cd.getInstitute();
+    }
+
+    /**
      * Creates a course.
      *
      * @return the created course

--- a/src/main/java/teammates/logic/sql/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/sql/InstructorsLogic.java
@@ -1,8 +1,13 @@
 package teammates.logic.sql;
 
+import java.util.List;
+
 import teammates.common.datatransfer.sqlattributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
 import teammates.storage.sql.InstructorsDb;
 
 /**
@@ -35,5 +40,184 @@ public final class InstructorsLogic {
     public InstructorAttributes createInstructor(InstructorAttributes instructorToAdd)
             throws InvalidParametersException, EntityAlreadyExistsException {
         return instructorsDb.createEntity(instructorToAdd);
+    }
+
+    /**
+     * Gets an instructor by unique constraint courseId-email.
+     */
+    public InstructorAttributes getInstructorForEmail(String courseId, String email) {
+        return instructorsDb.getInstructorForEmail(courseId, email);
+    }
+
+    /**
+     * Gets an instructor by unique ID.
+     */
+    public InstructorAttributes getInstructorById(String courseId, String email) {
+        return instructorsDb.getInstructorById(courseId, email);
+    }
+
+    /**
+     * Gets an instructor by unique constraint courseId-accountId.
+     */
+    public InstructorAttributes getInstructorForAccountId(String courseId, String accountId) {
+        return instructorsDb.getInstructorForAccountId(courseId, accountId);
+    }
+
+    /**
+     * Gets an instructor by unique constraint registrationKey.
+     */
+    public InstructorAttributes getInstructorForRegistrationKey(String registrationKey) {
+        return instructorsDb.getInstructorForRegistrationKey(registrationKey);
+    }
+
+    /**
+     * Gets all instructors of a course.
+     */
+    public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
+        List<InstructorAttributes> instructorReturnList = instructorsDb.getInstructorsForCourse(courseId);
+        InstructorAttributes.sortByName(instructorReturnList);
+
+        return instructorReturnList;
+    }
+
+    /**
+     * Gets all non-archived instructors associated with an accountId.
+     */
+    public List<InstructorAttributes> getInstructorsForAccountId(String accountId) {
+        return getInstructorsForAccountId(accountId, false);
+    }
+
+    /**
+     * Gets all instructors associated with an accountId.
+     *
+     * @param omitArchived whether archived instructors should be omitted or not
+     */
+    public List<InstructorAttributes> getInstructorsForAccountId(String accountId, boolean omitArchived) {
+        return instructorsDb.getInstructorsForAccountId(accountId, omitArchived);
+    }
+
+    /**
+     * Verifies that at least one instructor is displayed to students.
+     *
+     * @throws InstructorUpdateException if there is no instructor displayed to students.
+     */
+    void verifyAtLeastOneInstructorIsDisplayed(String courseId, boolean isOriginalInstructorDisplayed,
+                                               boolean isEditedInstructorDisplayed)
+            throws InstructorUpdateException {
+        List<InstructorAttributes> instructorsDisplayed = instructorsDb.getInstructorsDisplayedToStudents(courseId);
+        boolean isEditedInstructorChangedToNonVisible = isOriginalInstructorDisplayed && !isEditedInstructorDisplayed;
+        boolean isNoInstructorMadeVisible = instructorsDisplayed.isEmpty() && !isEditedInstructorDisplayed;
+
+        if (isNoInstructorMadeVisible || instructorsDisplayed.size() == 1 && isEditedInstructorChangedToNonVisible) {
+            throw new InstructorUpdateException("At least one instructor must be displayed to students");
+        }
+    }
+
+    /**
+     * Updates an instructor by {@link InstructorAttributes.UpdateOptionsWithAccountId}.
+     *
+     * <p>Cascade update the comments, responses and deadline extensions associated with the instructor.
+     *
+     * @return updated instructor
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the instructor cannot be found
+     */
+    public InstructorAttributes updateInstructorByAccountIdCascade(
+            InstructorAttributes.UpdateOptionsWithAccountId updateOptions)
+            throws InstructorUpdateException, InvalidParametersException, EntityDoesNotExistException {
+
+        InstructorAttributes originalInstructor =
+                instructorsDb.getInstructorForAccountId(updateOptions.getCourseId(), updateOptions.getAccountId());
+
+        if (originalInstructor == null) {
+            throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + updateOptions);
+        }
+
+        InstructorAttributes newInstructor = originalInstructor.getCopy();
+        newInstructor.update(updateOptions);
+
+        boolean isOriginalInstructorDisplayed = originalInstructor.isDisplayedToStudents();
+        verifyAtLeastOneInstructorIsDisplayed(originalInstructor.getCourseId(), isOriginalInstructorDisplayed,
+                newInstructor.isDisplayedToStudents());
+
+        InstructorAttributes updatedInstructor = instructorsDb.updateInstructorByGoogleId(updateOptions);
+
+        if (!originalInstructor.getEmail().equals(updatedInstructor.getEmail())) {
+            // TODO: cascade responses, comments, deadline extensions
+        }
+
+        return updatedInstructor;
+    }
+
+    /**
+     * Updates an instructor by {@link InstructorAttributes.UpdateOptionsWithEmail}.
+     *
+     * @return updated instructor
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the instructor cannot be found
+     */
+    public InstructorAttributes updateInstructorByEmail(InstructorAttributes.UpdateOptionsWithEmail updateOptions)
+            throws InstructorUpdateException, InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        InstructorAttributes originalInstructor =
+                instructorsDb.getInstructorForEmail(updateOptions.getCourseId(), updateOptions.getEmail());
+
+        if (originalInstructor == null) {
+            throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + updateOptions);
+        }
+
+        InstructorAttributes newInstructor = originalInstructor.getCopy();
+        newInstructor.update(updateOptions);
+
+        boolean isOriginalInstructorDisplayed = originalInstructor.isDisplayedToStudents();
+        verifyAtLeastOneInstructorIsDisplayed(originalInstructor.getCourseId(), isOriginalInstructorDisplayed,
+                newInstructor.isDisplayedToStudents());
+
+        return instructorsDb.updateInstructorByEmail(updateOptions);
+    }
+
+    /**
+     * Deletes an instructor cascade its associated feedback responses, deadline extensions and comments.
+     *
+     * <p>Fails silently if the student does not exist.
+     */
+    public void deleteInstructorCascade(String courseId, String email) {
+        InstructorAttributes instructorAttributes = getInstructorForEmail(courseId, email);
+        if (instructorAttributes == null) {
+            return;
+        }
+
+        instructorsDb.deleteInstructor(courseId, email);
+        // TODO: Cascade feedback responses, deadline extensions, comments
+    }
+
+    /**
+     * Checks if there are any other registered instructors that can modify instructors.
+     * If there are none, the instructor currently being edited will be granted the privilege
+     * of modifying instructors automatically.
+     *
+     * @param courseId         Id of the course.
+     * @param instructorToEdit Instructor that will be edited.
+     *                         This may be modified within the method.
+     */
+    public void updateToEnsureValidityOfInstructorsForTheCourse(String courseId, InstructorAttributes instructorToEdit) {
+        List<InstructorAttributes> instructors = getInstructorsForCourse(courseId);
+        int numOfInstrCanModifyInstructor = 0;
+        InstructorAttributes instrWithModifyInstructorPrivilege = null;
+        for (InstructorAttributes instructor : instructors) {
+            if (instructor.isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
+                numOfInstrCanModifyInstructor++;
+                instrWithModifyInstructorPrivilege = instructor;
+            }
+        }
+        boolean isLastRegInstructorWithPrivilege = numOfInstrCanModifyInstructor <= 1
+                && instrWithModifyInstructorPrivilege != null
+                && (!instrWithModifyInstructorPrivilege.isRegistered()
+                || instrWithModifyInstructorPrivilege.getAccountId()
+                .equals(instructorToEdit.getAccountId()));
+        if (isLastRegInstructorWithPrivilege) {
+            instructorToEdit.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+        }
     }
 }

--- a/src/main/java/teammates/storage/sql/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sql/EntitiesDb.java
@@ -1,5 +1,9 @@
 package teammates.storage.sql;
 
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -94,6 +98,9 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
      * Checks whether two values are the same.
      */
     <T> boolean hasSameValue(T oldValue, T newValue) {
+        if (oldValue == null) {
+            return newValue == null;
+        }
         return oldValue.equals(newValue);
     }
 
@@ -138,6 +145,17 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
      * Converts from entity to attributes.
      */
     abstract A makeAttributes(E entity);
+
+    /**
+     * Converts a collection of entities to a list of attributes.
+     */
+    List<A> makeAttributes(Collection<E> entities) {
+        List<A> attributes = new LinkedList<>();
+        for (E entity : entities) {
+            attributes.add(makeAttributes(entity));
+        }
+        return attributes;
+    }
 
     /**
      * Converts from entity to attributes.

--- a/src/main/java/teammates/storage/sql/InstructorsDb.java
+++ b/src/main/java/teammates/storage/sql/InstructorsDb.java
@@ -1,11 +1,14 @@
 package teammates.storage.sql;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 
 import teammates.common.datatransfer.sqlattributes.InstructorAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Instructor;
 
@@ -32,22 +35,324 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
         return instance;
     }
 
-    @Override
-    boolean hasExistingEntities(InstructorAttributes entityToCreate) {
+    /**
+     * Gets an instructor by unique constraint courseId-email.
+     */
+    public InstructorAttributes getInstructorForEmail(String courseId, String email) {
+        assert email != null;
+        assert courseId != null;
+
+        return makeAttributesOrNull(getInstructorEntityForEmail(courseId, email));
+    }
+
+    /**
+     * Gets an instructor by unique ID.
+     */
+    public InstructorAttributes getInstructorById(String courseId, String email) {
+        assert email != null;
+        assert courseId != null;
+
+        return makeAttributesOrNull(getInstructorEntityById(courseId, email));
+    }
+
+    /**
+     * Gets an instructor by unique constraint courseId-accountId.
+     */
+    public InstructorAttributes getInstructorForAccountId(String courseId, String accountId) {
+        assert accountId != null;
+        assert courseId != null;
+
+        return makeAttributesOrNull(getInstructorEntityForAccountId(courseId, accountId));
+    }
+
+    /**
+     * Gets an instructor by unique constraint registrationKey.
+     */
+    public InstructorAttributes getInstructorForRegistrationKey(String registrationKey) {
+        assert registrationKey != null;
+
+        return makeAttributesOrNull(getInstructorEntityForRegistrationKey(registrationKey.trim()));
+    }
+
+    /**
+     * Gets all instructors associated with a accountId.
+     *
+     * @param omitArchived whether archived instructors should be omitted or not
+     */
+    public List<InstructorAttributes> getInstructorsForAccountId(String accountId, boolean omitArchived) {
+        assert accountId != null;
+
+        return makeAttributes(getInstructorEntitiesForAccountId(accountId, omitArchived));
+    }
+
+    /**
+     * Gets all instructors of a course.
+     */
+    public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
+        assert courseId != null;
+
+        return makeAttributes(getInstructorEntitiesForCourse(courseId));
+    }
+
+    /**
+     * Gets all instructors that will be displayed to students of a course.
+     */
+    public List<InstructorAttributes> getInstructorsDisplayedToStudents(String courseId) {
+        assert courseId != null;
+
+        return makeAttributes(getInstructorEntitiesThatAreDisplayedInCourse(courseId));
+    }
+
+    /**
+     * Updates an instructor by {@link InstructorAttributes.UpdateOptionsWithAccountId}.
+     *
+     * @return updated instructor
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the instructor cannot be found
+     */
+    public InstructorAttributes updateInstructorByGoogleId(InstructorAttributes.UpdateOptionsWithAccountId updateOptions)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        Instructor instructor = getInstructorEntityForAccountId(updateOptions.getCourseId(), updateOptions.getAccountId());
+        if (instructor == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT + updateOptions);
+        }
+
+        InstructorAttributes newAttributes = makeAttributes(instructor);
+        newAttributes.update(updateOptions);
+
+        newAttributes.sanitizeForSaving();
+        if (!newAttributes.isValid()) {
+            throw new InvalidParametersException(newAttributes.getInvalidityInfo());
+        }
+
+        // update only if change
+        boolean hasSameAttributes =
+                this.hasSameValue(instructor.getName(), newAttributes.getName())
+                        && this.hasSameValue(instructor.getEmail(), newAttributes.getEmail())
+                        && this.hasSameValue(instructor.getIsArchived(), newAttributes.isArchived())
+                        && this.hasSameValue(instructor.getRole(), newAttributes.getRole())
+                        && this.hasSameValue(instructor.isDisplayedToStudents(), newAttributes.isDisplayedToStudents())
+                        && this.hasSameValue(instructor.getDisplayedName(), newAttributes.getDisplayedName())
+                        && this.hasSameValue(
+                        instructor.getInstructorPrivilegesAsText(), newAttributes.getInstructorPrivilegesAsText());
+        if (hasSameAttributes) {
+            log.info(String.format(
+                    OPTIMIZED_SAVING_POLICY_APPLIED, Instructor.class.getSimpleName(), updateOptions));
+            return newAttributes;
+        }
+
+        instructor.setName(newAttributes.getName());
+        instructor.setEmail(newAttributes.getEmail());
+        instructor.setIsArchived(newAttributes.isArchived());
+        instructor.setRole(newAttributes.getRole());
+        instructor.setIsDisplayedToStudents(newAttributes.isDisplayedToStudents());
+        instructor.setDisplayedName(newAttributes.getDisplayedName());
+        instructor.setInstructorPrivilegeAsText(newAttributes.getInstructorPrivilegesAsText());
+
+        saveEntity(instructor);
+
+        newAttributes = makeAttributes(instructor);
+
+        return newAttributes;
+    }
+
+    /**
+     * Updates an instructor by {@link InstructorAttributes.UpdateOptionsWithEmail}.
+     *
+     * @return updated instructor
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the instructor cannot be found
+     */
+    public InstructorAttributes updateInstructorByEmail(InstructorAttributes.UpdateOptionsWithEmail updateOptions)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        assert updateOptions != null;
+
+        Instructor instructor = getInstructorEntityForEmail(updateOptions.getCourseId(), updateOptions.getEmail());
+        if (instructor == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT + updateOptions);
+        }
+
+        InstructorAttributes newAttributes = makeAttributes(instructor);
+        newAttributes.update(updateOptions);
+
+        newAttributes.sanitizeForSaving();
+        if (!newAttributes.isValid()) {
+            throw new InvalidParametersException(newAttributes.getInvalidityInfo());
+        }
+
+        // update only if change
+        boolean hasSameAttributes =
+                this.hasSameValue(instructor.getName(), newAttributes.getName())
+                        && this.hasSameValue(instructor.getAccountId(), newAttributes.getAccountId())
+                        && this.hasSameValue(instructor.getIsArchived(), newAttributes.isArchived())
+                        && this.hasSameValue(instructor.getRole(), newAttributes.getRole())
+                        && this.hasSameValue(instructor.isDisplayedToStudents(), newAttributes.isDisplayedToStudents())
+                        && this.hasSameValue(instructor.getDisplayedName(), newAttributes.getDisplayedName())
+                        && this.hasSameValue(
+                        instructor.getInstructorPrivilegesAsText(), newAttributes.getInstructorPrivilegesAsText());
+        if (hasSameAttributes) {
+            log.info(String.format(OPTIMIZED_SAVING_POLICY_APPLIED, Instructor.class.getSimpleName(), updateOptions));
+            return newAttributes;
+        }
+
+        instructor.setAccountId(newAttributes.getAccountId());
+        instructor.setName(newAttributes.getName());
+        instructor.setIsArchived(newAttributes.isArchived());
+        instructor.setRole(newAttributes.getRole());
+        instructor.setIsDisplayedToStudents(newAttributes.isDisplayedToStudents());
+        instructor.setDisplayedName(newAttributes.getDisplayedName());
+        instructor.setInstructorPrivilegeAsText(newAttributes.getInstructorPrivilegesAsText());
+
+        saveEntity(instructor);
+
+        newAttributes = makeAttributes(instructor);
+
+        return newAttributes;
+    }
+
+    /**
+     * Deletes the instructor specified by courseId and email.
+     *
+     * <p>Fails silently if the instructor does not exist.
+     */
+    public void deleteInstructor(String courseId, String email) {
+        assert email != null;
+        assert courseId != null;
+
+        Instructor instructorToDelete = getInstructorEntityForEmail(courseId, email);
+
+        if (instructorToDelete == null) {
+            return;
+        }
+
+        deleteEntity(instructorToDelete);
+    }
+
+    private Instructor getInstructorEntityForAccountId(String courseId, String accountId) {
         Session session = HibernateUtil.getSessionFactory().openSession();
 
         CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
         CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
         Root<Instructor> root = cr.from(Instructor.class);
-        Predicate sameAccount = criteriaBuilder.equal(root.get("accountId"), entityToCreate.getAccountId());
-        Predicate sameCourse = criteriaBuilder.equal(root.get("courseId"), entityToCreate.getCourseId());
-        cr.select(root).where(criteriaBuilder.and(sameAccount, sameCourse));
+        Predicate isSameAccount = criteriaBuilder.equal(root.get("accountId"), accountId);
+        Predicate isSameCourse = criteriaBuilder.equal(root.get("courseId"), courseId);
+        cr.select(root).where(criteriaBuilder.and(isSameAccount, isSameCourse));
 
         Query<Instructor> query = session.createQuery(cr);
         List<Instructor> results = query.getResultList();
         session.close();
 
-        return !results.isEmpty();
+        if (results.isEmpty()) {
+            return null;
+        }
+
+        return results.get(0);
+    }
+
+    private Instructor getInstructorEntityForEmail(String courseId, String email) {
+        return getInstructorEntityById(courseId, email);
+    }
+
+    private Instructor getInstructorEntityById(String courseId, String email) {
+        Session session = HibernateUtil.getSessionFactory().openSession();
+        Instructor instructor = session.get(Instructor.class, Instructor.generateId(email, courseId));
+        session.close();
+        return instructor;
+    }
+
+    private List<Instructor> getInstructorEntitiesThatAreDisplayedInCourse(String courseId) {
+        Session session = HibernateUtil.getSessionFactory().openSession();
+
+        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
+        Root<Instructor> root = cr.from(Instructor.class);
+        Predicate isSameCourse = criteriaBuilder.equal(root.get("courseId"), courseId);
+        Predicate isDisplayedToStudents = criteriaBuilder.equal(root.get("isDisplayedToStudents"), true);
+        cr.select(root).where(criteriaBuilder.and(isSameCourse, isDisplayedToStudents));
+
+        Query<Instructor> query = session.createQuery(cr);
+        List<Instructor> results = query.getResultList();
+        session.close();
+
+        return results;
+    }
+
+    private Instructor getInstructorEntityForRegistrationKey(String key) {
+        Session session = HibernateUtil.getSessionFactory().openSession();
+
+        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
+        Root<Instructor> root = cr.from(Instructor.class);
+        Predicate isSameRegistrationKey = criteriaBuilder.equal(root.get("registrationKey"), key);
+        cr.select(root).where(isSameRegistrationKey);
+
+        Query<Instructor> query = session.createQuery(cr);
+        List<Instructor> instructorList = query.getResultList();
+        session.close();
+
+        // If registration key detected is not unique, something is wrong
+        if (instructorList.size() > 1) {
+            log.severe("Duplicate registration keys detected for: "
+                    + instructorList.stream().map(i -> i.getUniqueId()).collect(Collectors.joining(", ")));
+        }
+
+        if (instructorList.isEmpty()) {
+            return null;
+        }
+
+        return instructorList.get(0);
+    }
+
+    /**
+     * Omits instructors with isArchived == omitArchived.
+     * This means that the corresponding course is archived by the instructor.
+     */
+    private List<Instructor> getInstructorEntitiesForAccountId(String accountId, boolean omitArchived) {
+        Session session = HibernateUtil.getSessionFactory().openSession();
+
+        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
+        Root<Instructor> root = cr.from(Instructor.class);
+        Predicate isSameAccount = criteriaBuilder.equal(root.get("accountId"), accountId);
+
+        if (omitArchived) {
+            Predicate isNotArchived = criteriaBuilder.equal(root.get("isArchived"), false);
+            cr.select(root).where(criteriaBuilder.and(isSameAccount, isNotArchived));
+        } else {
+            cr.select(root).where(isSameAccount);
+        }
+
+        Query<Instructor> query = session.createQuery(cr);
+        List<Instructor> results = query.getResultList();
+        session.close();
+
+        return results;
+    }
+
+    private List<Instructor> getInstructorEntitiesForCourse(String courseId) {
+        Session session = HibernateUtil.getSessionFactory().openSession();
+
+        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
+        Root<Instructor> root = cr.from(Instructor.class);
+        Predicate isSameCourse = criteriaBuilder.equal(root.get("courseId"), courseId);
+        cr.select(root).where(isSameCourse);
+
+        Query<Instructor> query = session.createQuery(cr);
+        List<Instructor> results = query.getResultList();
+        session.close();
+
+        return results;
+    }
+
+    @Override
+    boolean hasExistingEntities(InstructorAttributes entityToCreate) {
+        Instructor instructor = getInstructorEntityById(
+                entityToCreate.getCourseId(), entityToCreate.getEmail());
+
+        return instructor != null;
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -37,7 +37,7 @@ public class Instructor extends BaseEntity {
     /**
      * The account id of the instructor, used as the foreign key to locate the Account object.
      */
-    @Column(name = "account_id", nullable = false)
+    @Column(name = "account_id")
     private String accountId;
 
     /** The foreign key to locate the Course object. */

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -109,6 +109,22 @@ abstract class BasicFeedbackSubmissionAction extends Action {
     }
 
     /**
+     * Gets the instructor involved in the submission process.
+     */
+    teammates.common.datatransfer.sqlattributes.InstructorAttributes getSqlInstructorOfCourseFromRequest(String courseId) {
+        String moderatedPerson = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON);
+        String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
+
+        if (!StringHelper.isEmpty(moderatedPerson)) {
+            return logicNew.getInstructorForEmail(courseId, moderatedPerson);
+        } else if (!StringHelper.isEmpty(previewAsPerson)) {
+            return logicNew.getInstructorForEmail(courseId, previewAsPerson);
+        } else {
+            return getPossiblyUnregisteredSqlInstructor(courseId);
+        }
+    }
+
+    /**
      * Checks the access control for instructor feedback submission.
      */
     void checkAccessControlForInstructorFeedbackSubmission(


### PR DESCRIPTION
Fixes #15

Migrates logic related to instructors CRUD.

Additional pointers that we can explore that is not included in this PR:
- Using JSON to store instructor privileges
- Using auto-incrementing ID instead of generating from course ID an email
