### PR TITLE
Implement session-per-request model

### DIFF
--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -27,6 +27,7 @@ public final class HibernateUtil {
                 .setProperty("hibernate.connection.url", url)
                 .setProperty("hibernate.hbm2ddl.auto", "validate")
                 .setProperty("show_sql", "true")
+                .setProperty("hibernate.current_session_context_class", "thread")
                 .addPackage("teammates.storage.sqlentity")
                 .addAnnotatedClass(Course.class)
                 .addAnnotatedClass(Instructor.class);

--- a/src/main/java/teammates/logic/sql/CoursesLogic.java
+++ b/src/main/java/teammates/logic/sql/CoursesLogic.java
@@ -10,6 +10,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
 import teammates.logic.core.AccountsLogic;
 import teammates.storage.sql.CoursesDb;
 
@@ -90,6 +91,9 @@ public final class CoursesLogic {
         try {
             instructorsLogic.createInstructor(instructor);
         } catch (EntityAlreadyExistsException | InvalidParametersException e) {
+            // roll back the transaction
+            HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
+
             String errorMessage = "Unexpected exception while trying to create instructor for a new course "
                     + System.lineSeparator() + instructor.toString();
             assert false : errorMessage;

--- a/src/main/java/teammates/logic/sql/CoursesLogic.java
+++ b/src/main/java/teammates/logic/sql/CoursesLogic.java
@@ -90,8 +90,6 @@ public final class CoursesLogic {
         try {
             instructorsLogic.createInstructor(instructor);
         } catch (EntityAlreadyExistsException | InvalidParametersException e) {
-            // roll back the transaction
-            coursesDb.deleteCourse(createdCourse.getId());
             String errorMessage = "Unexpected exception while trying to create instructor for a new course "
                     + System.lineSeparator() + instructor.toString();
             assert false : errorMessage;

--- a/src/main/java/teammates/storage/sql/CoursesDb.java
+++ b/src/main/java/teammates/storage/sql/CoursesDb.java
@@ -135,9 +135,6 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     }
 
     private Course getCourseEntity(String courseId) {
-        // Flushing forces the creation date of courses created in the same session
-        // to be automatically updated, otherwise it would be null
-        HibernateUtil.getSessionFactory().getCurrentSession().flush();
         return HibernateUtil.getSessionFactory().getCurrentSession()
                 .get(Course.class, courseId);
     }

--- a/src/main/java/teammates/storage/sql/CoursesDb.java
+++ b/src/main/java/teammates/storage/sql/CoursesDb.java
@@ -2,8 +2,6 @@ package teammates.storage.sql;
 
 import java.time.Instant;
 
-import org.hibernate.Session;
-
 import teammates.common.datatransfer.sqlattributes.CourseAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -87,9 +85,7 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     public void deleteCourse(String courseId) {
         assert courseId != null;
 
-        Course course = getCourseEntity(courseId);
-
-        deleteEntity(course);
+        deleteEntity(getCourseEntity(courseId));
     }
 
     /**
@@ -139,10 +135,8 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     }
 
     private Course getCourseEntity(String courseId) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
-        Course course = session.get(Course.class, courseId);
-        session.close();
-        return course;
+        return HibernateUtil.getSessionFactory().getCurrentSession()
+                .get(Course.class, courseId);
     }
 
 }

--- a/src/main/java/teammates/storage/sql/CoursesDb.java
+++ b/src/main/java/teammates/storage/sql/CoursesDb.java
@@ -135,6 +135,9 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     }
 
     private Course getCourseEntity(String courseId) {
+        // Flushing forces the creation date of courses created in the same session
+        // to be automatically updated, otherwise it would be null
+        HibernateUtil.getSessionFactory().getCurrentSession().flush();
         return HibernateUtil.getSessionFactory().getCurrentSession()
                 .get(Course.class, courseId);
     }

--- a/src/main/java/teammates/storage/sql/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sql/EntitiesDb.java
@@ -39,8 +39,6 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
 
     static final Logger log = Logger.getLogger();
 
-    protected final Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
-
     /**
      * Creates the entity in the database.
      *

--- a/src/main/java/teammates/storage/sql/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sql/EntitiesDb.java
@@ -68,7 +68,7 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
         E entity = convertToEntityForSaving(entityToAdd);
 
         HibernateUtil.getSessionFactory().getCurrentSession().persist(entity);
-        log.info("Entity created: " + JsonUtils.toJson(entityToAdd));
+        log.info("Entity marked for insertion: " + JsonUtils.toJson(entityToAdd));
 
         return makeAttributes(entity);
     }

--- a/src/main/java/teammates/storage/sql/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sql/EntitiesDb.java
@@ -4,10 +4,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.hibernate.HibernateException;
 import org.hibernate.Session;
-import org.hibernate.Transaction;
-
 import teammates.common.datatransfer.sqlattributes.EntityAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
@@ -42,6 +39,8 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
 
     static final Logger log = Logger.getLogger();
 
+    protected final Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
     /**
      * Creates the entity in the database.
      *
@@ -70,17 +69,8 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
 
         E entity = convertToEntityForSaving(entityToAdd);
 
-        Transaction tx = null;
-
-        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            tx = session.beginTransaction();
-            session.persist(entity);
-            tx.commit();
-            log.info("Entity created: " + JsonUtils.toJson(entityToAdd));
-        } catch (HibernateException e) {
-            // TODO: Handle errors
-            tx.rollback();
-        }
+        HibernateUtil.getSessionFactory().getCurrentSession().persist(entity);
+        log.info("Entity created: " + JsonUtils.toJson(entityToAdd));
 
         return makeAttributes(entity);
     }
@@ -110,17 +100,8 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
     void saveEntity(E entityToSave) {
         assert entityToSave != null;
 
-        Transaction tx = null;
-
-        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            tx = session.beginTransaction();
-            session.merge(entityToSave);
-            tx.commit();
-            log.info("Entity saved: " + JsonUtils.toJson(entityToSave));
-        } catch (HibernateException e) {
-            // TODO: Handle errors
-            tx.rollback();
-        }
+        HibernateUtil.getSessionFactory().getCurrentSession().merge(entityToSave);
+        log.info("Entity saved: " + JsonUtils.toJson(entityToSave));
     }
 
     /**
@@ -129,16 +110,7 @@ abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttributes<E>> {
     void deleteEntity(E entityToDelete) {
         assert entityToDelete != null;
 
-        Transaction tx = null;
-
-        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            tx = session.beginTransaction();
-            session.remove(entityToDelete);
-            tx.commit();
-        } catch (HibernateException e) {
-            // TODO: Handle errors
-            tx.rollback();
-        }
+        HibernateUtil.getSessionFactory().getCurrentSession().remove(entityToDelete);
     }
 
     /**

--- a/src/main/java/teammates/storage/sql/InstructorsDb.java
+++ b/src/main/java/teammates/storage/sql/InstructorsDb.java
@@ -3,11 +3,13 @@ package teammates.storage.sql;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hibernate.Session;
 import org.hibernate.query.Query;
 
 import teammates.common.datatransfer.sqlattributes.InstructorAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Instructor;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -229,6 +231,8 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private Instructor getInstructorEntityForAccountId(String courseId, String accountId) {
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
         CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
         CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
@@ -253,10 +257,14 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private Instructor getInstructorEntityById(String courseId, String email) {
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
         return currentSession.get(Instructor.class, Instructor.generateId(email, courseId));
     }
 
     private List<Instructor> getInstructorEntitiesThatAreDisplayedInCourse(String courseId) {
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
         CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
         CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
@@ -273,6 +281,8 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private Instructor getInstructorEntityForRegistrationKey(String key) {
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
         CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
         CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
@@ -302,6 +312,8 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
      * This means that the corresponding course is archived by the instructor.
      */
     private List<Instructor> getInstructorEntitiesForAccountId(String accountId, boolean omitArchived) {
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
         CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
         CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
@@ -322,6 +334,8 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private List<Instructor> getInstructorEntitiesForCourse(String courseId) {
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+
         CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
         CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 

--- a/src/main/java/teammates/storage/sql/InstructorsDb.java
+++ b/src/main/java/teammates/storage/sql/InstructorsDb.java
@@ -3,13 +3,11 @@ package teammates.storage.sql;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hibernate.Session;
 import org.hibernate.query.Query;
 
 import teammates.common.datatransfer.sqlattributes.InstructorAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Instructor;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -231,18 +229,17 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private Instructor getInstructorEntityForAccountId(String courseId, String accountId) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
+        CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
+        CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
-        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
-        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
-        Root<Instructor> root = cr.from(Instructor.class);
+        Root<Instructor> root = crq.from(Instructor.class);
         Predicate isSameAccount = criteriaBuilder.equal(root.get("accountId"), accountId);
         Predicate isSameCourse = criteriaBuilder.equal(root.get("courseId"), courseId);
-        cr.select(root).where(criteriaBuilder.and(isSameAccount, isSameCourse));
 
-        Query<Instructor> query = session.createQuery(cr);
+        crq.select(root).where(criteriaBuilder.and(isSameAccount, isSameCourse));
+
+        Query<Instructor> query = currentSession.createQuery(crq);
         List<Instructor> results = query.getResultList();
-        session.close();
 
         if (results.isEmpty()) {
             return null;
@@ -256,41 +253,36 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private Instructor getInstructorEntityById(String courseId, String email) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
-        Instructor instructor = session.get(Instructor.class, Instructor.generateId(email, courseId));
-        session.close();
-        return instructor;
+        return currentSession.get(Instructor.class, Instructor.generateId(email, courseId));
     }
 
     private List<Instructor> getInstructorEntitiesThatAreDisplayedInCourse(String courseId) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
+        CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
+        CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
-        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
-        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
-        Root<Instructor> root = cr.from(Instructor.class);
+        Root<Instructor> root = crq.from(Instructor.class);
         Predicate isSameCourse = criteriaBuilder.equal(root.get("courseId"), courseId);
         Predicate isDisplayedToStudents = criteriaBuilder.equal(root.get("isDisplayedToStudents"), true);
-        cr.select(root).where(criteriaBuilder.and(isSameCourse, isDisplayedToStudents));
 
-        Query<Instructor> query = session.createQuery(cr);
+        crq.select(root).where(criteriaBuilder.and(isSameCourse, isDisplayedToStudents));
+
+        Query<Instructor> query = currentSession.createQuery(crq);
         List<Instructor> results = query.getResultList();
-        session.close();
 
         return results;
     }
 
     private Instructor getInstructorEntityForRegistrationKey(String key) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
+        CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
+        CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
-        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
-        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
-        Root<Instructor> root = cr.from(Instructor.class);
+        Root<Instructor> root = crq.from(Instructor.class);
         Predicate isSameRegistrationKey = criteriaBuilder.equal(root.get("registrationKey"), key);
-        cr.select(root).where(isSameRegistrationKey);
 
-        Query<Instructor> query = session.createQuery(cr);
+        crq.select(root).where(isSameRegistrationKey);
+
+        Query<Instructor> query = currentSession.createQuery(crq);
         List<Instructor> instructorList = query.getResultList();
-        session.close();
 
         // If registration key detected is not unique, something is wrong
         if (instructorList.size() > 1) {
@@ -310,39 +302,35 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
      * This means that the corresponding course is archived by the instructor.
      */
     private List<Instructor> getInstructorEntitiesForAccountId(String accountId, boolean omitArchived) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
+        CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
+        CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
-        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
-        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
-        Root<Instructor> root = cr.from(Instructor.class);
+        Root<Instructor> root = crq.from(Instructor.class);
         Predicate isSameAccount = criteriaBuilder.equal(root.get("accountId"), accountId);
 
         if (omitArchived) {
             Predicate isNotArchived = criteriaBuilder.equal(root.get("isArchived"), false);
-            cr.select(root).where(criteriaBuilder.and(isSameAccount, isNotArchived));
+            crq.select(root).where(criteriaBuilder.and(isSameAccount, isNotArchived));
         } else {
-            cr.select(root).where(isSameAccount);
+            crq.select(root).where(isSameAccount);
         }
 
-        Query<Instructor> query = session.createQuery(cr);
+        Query<Instructor> query = currentSession.createQuery(crq);
         List<Instructor> results = query.getResultList();
-        session.close();
 
         return results;
     }
 
     private List<Instructor> getInstructorEntitiesForCourse(String courseId) {
-        Session session = HibernateUtil.getSessionFactory().openSession();
+        CriteriaBuilder criteriaBuilder = currentSession.getCriteriaBuilder();
+        CriteriaQuery<Instructor> crq = criteriaBuilder.createQuery(Instructor.class);
 
-        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
-        CriteriaQuery<Instructor> cr = criteriaBuilder.createQuery(Instructor.class);
-        Root<Instructor> root = cr.from(Instructor.class);
+        Root<Instructor> root = crq.from(Instructor.class);
         Predicate isSameCourse = criteriaBuilder.equal(root.get("courseId"), courseId);
-        cr.select(root).where(isSameCourse);
+        crq.select(root).where(isSameCourse);
 
-        Query<Instructor> query = session.createQuery(cr);
+        Query<Instructor> query = currentSession.createQuery(crq);
         List<Instructor> results = query.getResultList();
-        session.close();
 
         return results;
     }

--- a/src/main/java/teammates/ui/servlets/HibernateSessionRequestFilter.java
+++ b/src/main/java/teammates/ui/servlets/HibernateSessionRequestFilter.java
@@ -1,0 +1,55 @@
+package teammates.ui.servlets;
+
+import org.hibernate.SessionFactory;
+import teammates.common.util.HibernateUtil;
+import teammates.common.util.Logger;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+public class HibernateSessionRequestFilter implements Filter {
+
+    private static final Logger log = Logger.getLogger();
+    private SessionFactory sessionFactory;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        sessionFactory = HibernateUtil.getSessionFactory();
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        try {
+            sessionFactory.getCurrentSession().beginTransaction();
+
+            chain.doFilter(request, response);
+
+            sessionFactory.getCurrentSession().getTransaction().commit();
+            sessionFactory.getCurrentSession().close();
+        } catch (Throwable ex) {
+            ex.printStackTrace();
+
+            // Rollback the transaction
+            try {
+                if (sessionFactory.getCurrentSession().getTransaction().isActive()) {
+                    sessionFactory.getCurrentSession().getTransaction().rollback();
+                }
+            } catch (Throwable rbEx) {
+                log.severe("Could not rollback transaction", rbEx);
+            }
+
+            throw new ServletException(ex);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // nothing to do
+    }
+}

--- a/src/main/java/teammates/ui/servlets/HibernateSessionRequestFilter.java
+++ b/src/main/java/teammates/ui/servlets/HibernateSessionRequestFilter.java
@@ -3,6 +3,7 @@ package teammates.ui.servlets;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import teammates.common.util.HibernateUtil;
+import teammates.common.util.Logger;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -15,6 +16,7 @@ import java.io.IOException;
 public class HibernateSessionRequestFilter implements Filter {
 
     private SessionFactory sessionFactory;
+    private static final Logger log = Logger.getLogger();
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -24,11 +26,15 @@ public class HibernateSessionRequestFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
         Session currentSession = sessionFactory.getCurrentSession();
+
+        log.info("Beginning transaction in session: " + currentSession);
         currentSession.beginTransaction();
 
         chain.doFilter(request, response);
 
         currentSession.getTransaction().commit();
+        log.info("Transaction successfully committed in session: " + currentSession);
+
         currentSession.close();
     }
 

--- a/src/main/java/teammates/ui/servlets/HibernateSessionRequestFilter.java
+++ b/src/main/java/teammates/ui/servlets/HibernateSessionRequestFilter.java
@@ -33,9 +33,6 @@ public class HibernateSessionRequestFilter implements Filter {
             sessionFactory.getCurrentSession().getTransaction().commit();
             sessionFactory.getCurrentSession().close();
         } catch (Throwable ex) {
-            ex.printStackTrace();
-
-            // Rollback the transaction
             try {
                 if (sessionFactory.getCurrentSession().getTransaction().isActive()) {
                     sessionFactory.getCurrentSession().getTransaction().rollback();

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -11,6 +11,7 @@ import org.apache.http.HttpStatus;
 
 import com.google.cloud.datastore.DatastoreException;
 
+import org.hibernate.HibernateException;
 import teammates.common.datatransfer.logs.RequestLogUser;
 import teammates.common.exception.DeadlineExceededException;
 import teammates.common.util.Logger;
@@ -92,6 +93,10 @@ public class WebApiServlet extends HttpServlet {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
             log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: " + e.getMessage(), e);
             throwError(resp, statusCode, e.getMessage());
+        } catch (HibernateException hbe) {
+            statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+            log.severe(hbe.getClass().getSimpleName() + " caught by WebApiServlet: " + hbe.getMessage(), hbe);
+            throwError(resp, statusCode, hbe.getMessage());
         } catch (Throwable t) {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
             log.severe(t.getClass().getSimpleName() + " caught by WebApiServlet: " + t.getMessage(), t);

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -89,14 +89,10 @@ public class WebApiServlet extends HttpServlet {
             statusCode = HttpStatus.SC_GATEWAY_TIMEOUT;
             log.severe(dee.getClass().getSimpleName() + " caught by WebApiServlet", dee);
             throwError(resp, statusCode, "The request exceeded the server timeout limit. Please try again later.");
-        } catch (DatastoreException e) {
+        } catch (DatastoreException | HibernateException e) {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
             log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: " + e.getMessage(), e);
             throwError(resp, statusCode, e.getMessage());
-        } catch (HibernateException hbe) {
-            statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
-            log.severe(hbe.getClass().getSimpleName() + " caught by WebApiServlet: " + hbe.getMessage(), hbe);
-            throwError(resp, statusCode, hbe.getMessage());
         } catch (Throwable t) {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
             log.severe(t.getClass().getSimpleName() + " caught by WebApiServlet: " + t.getMessage(), t);

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -95,6 +95,11 @@ class CreateCourseAction extends Action {
             throw new InvalidHttpRequestBodyException(e);
         }
 
+        // Forces SQL statements to be executed to synchronize the JDBC connection's
+        // state with the state of objects held in memory, otherwise the
+        // creation timestamp of the newly created Course object will be null
+        HibernateUtil.getSessionFactory().getCurrentSession().flush();
+
         return new JsonResult(new CourseData(logicNew.getCourse(newCourseId)));
     }
 }

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -9,6 +9,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
+import teammates.common.util.HibernateUtil;
 import teammates.ui.output.CourseData;
 import teammates.ui.request.CourseCreateRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
@@ -83,10 +84,14 @@ class CreateCourseAction extends Action {
             logicNew.createCourseAndInstructor(userInfo.getId(), sqlCourseAttributes);
 
         } catch (EntityAlreadyExistsException e) {
+            HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
+
             throw new InvalidOperationException("The course ID " + courseAttributes.getId()
                     + " has been used by another course, possibly by some other user."
                     + " Please try again with a different course ID.", e);
         } catch (InvalidParametersException e) {
+            HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
+
             throw new InvalidHttpRequestBodyException(e);
         }
 

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -5,6 +5,7 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
 import teammates.common.util.SanitizationHelper;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
@@ -59,9 +60,13 @@ class CreateInstructorAction extends Action {
 
             return new JsonResult(new InstructorData(createdInstructor));
         } catch (EntityAlreadyExistsException e) {
+            HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
+
             throw new InvalidOperationException(
                     "An instructor with the same email address already exists in the course.", e);
         } catch (InvalidParametersException e) {
+            HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
+
             throw new InvalidHttpRequestBodyException(e);
         }
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -48,6 +48,16 @@
         <url-pattern>/auto/*</url-pattern>
         <url-pattern>/worker/*</url-pattern>
     </filter-mapping>
+    <filter>
+        <filter-name>HibernateSessionRequestFilter</filter-name>
+        <filter-class>teammates.ui.servlets.HibernateSessionRequestFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>HibernateSessionRequestFilter</filter-name>
+        <url-pattern>/webapi/*</url-pattern>
+        <url-pattern>/auto/*</url-pattern>
+        <url-pattern>/worker/*</url-pattern>
+    </filter-mapping>
     <listener>
         <listener-class>teammates.storage.api.OfyHelper</listener-class>
     </listener>

--- a/src/test/java/teammates/test/BaseTestCaseWithLocalSqlDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithLocalSqlDatabaseAccess.java
@@ -31,6 +31,7 @@ public abstract class BaseTestCaseWithLocalSqlDatabaseAccess extends BaseTestCas
 
     @AfterClass
     public static void closeContainer() {
+        HibernateUtil.getSessionFactory().getCurrentSession().close();
         pgsql.close();
     }
 

--- a/src/test/java/teammates/test/BaseTestCaseWithLocalSqlDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithLocalSqlDatabaseAccess.java
@@ -1,5 +1,6 @@
 package teammates.test;
 
+import org.hibernate.Session;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -23,6 +24,9 @@ public abstract class BaseTestCaseWithLocalSqlDatabaseAccess extends BaseTestCas
         FlywayUtil.getFlywayInst(pgsql.getJdbcUrl(), pgsql.getUsername(), pgsql.getPassword()).migrate();
         HibernateUtil.setSessionFactoryForTesting(
                 pgsql.getUsername(), pgsql.getPassword(), pgsql.getJdbcUrl());
+
+        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+        currentSession.beginTransaction();
     }
 
     @AfterClass


### PR DESCRIPTION
Fixes #25 

This PR implements the session-per-request model, aka the ["one session - one database transaction" programming model](https://docs.jboss.org/hibernate/orm/3.3/reference/en-US/html/architecture.html#architecture-current-session). As Hibernate's [`Session` object is not thread-safe](https://docs.jboss.org/hibernate/stable/core.old/reference/en/html/transactions.html), we should not be sharing a session across multiple threads. On the other hand, creating a new session for each database operation is expensive. Moreover, we should be leveraging on the atomicity of transactions i.e. for operations which are meant to be performed as a unit, they should either all be executed successfully or nothing is committed. Hence, I propose we use the session-per-request model, where all database operations to be performed in a single request are wrapped in one transaction. A request can be seen as one atomic unit of operation.

**Solution:**
In `HibernateUtil`, the Hibernate instance is configured to set the `hibernate.current_session_context_class` property to `thread`
* This implies that current sessions are tracked by thread of execution. The benefit of this is that we do not have to call `HibernateUtil.getSessionFactory().openSession()` anywhere in our code, neither do we have to pass the `Session` object as function parameters from layer to layer to keep a reference to the `Session` object. Instead, to obtain the current session bound to the thread, simply call `HibernateUtil.getSessionFactory().getCurrentSession()` from whichever method that needs to use the `Session` object.

A new servlet filter `HibernateSessionRequestFilter` is added
* The filter intercepts requests and starts a new transaction for each request, and after the response is sent back to the client, the filter closes the transaction and ends the session.
    
