### PR TITLE
Test axe tests

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -1,0 +1,52 @@
+name: Accessibility Tests
+
+on:
+  push:
+    branches:
+      - master 
+      - release
+  pull_request:
+    branches:
+      - master 
+      - release
+jobs:
+  axe-testing:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [firefox]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Update Property File 
+        run: mv src/e2e/resources/test.ci-${{ matrix.browser }}.properties src/e2e/resources/test.properties
+      - name: Run Solr search service + local Datastore emulator
+        run: docker-compose up -d
+      - name: Create Config Files
+        run: ./gradlew createConfigs testClasses generateTypes 
+      - name: Install Frontend Dependencies
+        run: npm ci 
+      - name: Build Frontend Bundle 
+        run: npm run build
+      - name: Start Server
+        run: |
+          ./gradlew serverRun &
+          ./wait-for-server.sh
+      - name: Start Tests 
+        run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew axeTests 

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     testImplementation("com.tngtech.archunit:archunit:0.11.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.seleniumhq.selenium:selenium-java:4.3.0")
-    testImplementation("com.deque.html.axe-core:selenium:4.3.0")
+    testImplementation("com.deque.html.axe-core:selenium:4.6.0")
     testImplementation(testng)
     // For supporting authorization code flow locally
     testImplementation("com.google.oauth-client:google-oauth-client-jetty:1.34.1")
@@ -565,37 +565,22 @@ task e2eTests {
     e2eTests.dependsOn "e2eTestTry${id}"
 }
 
-task axeTests {
-    description "Runs the full accessibility test suite and retries failed test up to ${numOfTestRetries} times."
-    group "Test"
-}
-
-(1..numOfTestRetries + 1).each { id ->
-    def isFirstTry = id == 1
-    def isLastRetry = id == numOfTestRetries + 1
-
-    task "axeTestTry${id}"(type: Test) {
-        useTestNG()
-        options.suites isFirstTry ? "src/e2e/resources/testng-axe.xml" : file("${buildDir}/reports/axe-test-try-${id - 1}/testng-failed.xml")
-        options.outputDirectory = file("${buildDir}/reports/axe-test-try-${id}")
-        options.useDefaultListeners = true
-        ignoreFailures = !isLastRetry
-        maxHeapSize = "1g"
-        reports.html.required = false
-        reports.junitXml.required = false
-        jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
-        testLogging {
-            events "passed"
-        }
-        afterTest afterTestClosure
-        if (isFirstTry) {
-            afterSuite checkTestNgFailureClosure
-        }
-        onlyIf {
-            isFirstTry || file("${buildDir}/reports/axe-test-try-${id - 1}/testng-failed.xml").exists()
-        }
+task axeTests(type: Test) {
+    description "Runs the full accessibility test suite."
+    useTestNG()
+    options.suites "src/e2e/resources/testng-axe.xml"
+    options.outputDirectory = file("${buildDir}/reports/axe-test")
+    options.useDefaultListeners = true
+    ignoreFailures = false
+    maxHeapSize = "1g"
+    reports.html.required = false
+    reports.junitXml.required = false
+    jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
+    testLogging {
+        events "passed"
     }
-    axeTests.dependsOn "axeTestTry${id}"
+    afterTest afterTestClosure
+    afterSuite checkTestNgFailureClosure
 }
 
 // COVERAGE TASKS

--- a/build.gradle
+++ b/build.gradle
@@ -565,21 +565,37 @@ task e2eTests {
     e2eTests.dependsOn "e2eTestTry${id}"
 }
 
-task axeTests(type: Test) {
-    useTestNG()
-    options.suites "src/e2e/resources/testng-axe.xml"
-    options.outputDirectory = file("${buildDir}/reports/axe-test")
-    options.useDefaultListeners = true
-    ignoreFailures = false
-    maxHeapSize = "1g"
-    reports.html.required = false
-    reports.junitXml.required = false
-    jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
-    testLogging {
-        events "passed"
+task axeTests {
+    description "Runs the full accessibility test suite and retries failed test up to ${numOfTestRetries} times."
+    group "Test"
+}
+
+(1..numOfTestRetries + 1).each { id ->
+    def isFirstTry = id == 1
+    def isLastRetry = id == numOfTestRetries + 1
+
+    task "axeTestTry${id}"(type: Test) {
+        useTestNG()
+        options.suites isFirstTry ? "src/e2e/resources/testng-axe.xml" : file("${buildDir}/reports/axe-test-try-${id - 1}/testng-failed.xml")
+        options.outputDirectory = file("${buildDir}/reports/axe-test-try-${id}")
+        options.useDefaultListeners = true
+        ignoreFailures = !isLastRetry
+        maxHeapSize = "1g"
+        reports.html.required = false
+        reports.junitXml.required = false
+        jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
+        testLogging {
+            events "passed"
+        }
+        afterTest afterTestClosure
+        if (isFirstTry) {
+            afterSuite checkTestNgFailureClosure
+        }
+        onlyIf {
+            isFirstTry || file("${buildDir}/reports/axe-test-try-${id - 1}/testng-failed.xml").exists()
+        }
     }
-    afterTest afterTestClosure
-    afterSuite checkTestNgFailureClosure
+    axeTests.dependsOn "axeTestTry${id}"
 }
 
 // COVERAGE TASKS

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     testImplementation("com.tngtech.archunit:archunit:0.11.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.seleniumhq.selenium:selenium-java:4.3.0")
+    testImplementation("com.deque.html.axe-core:selenium:4.3.0")
     testImplementation(testng)
     // For supporting authorization code flow locally
     testImplementation("com.google.oauth-client:google-oauth-client-jetty:1.34.1")
@@ -562,6 +563,23 @@ task e2eTests {
         }
     }
     e2eTests.dependsOn "e2eTestTry${id}"
+}
+
+task axeTests(type: Test) {
+    useTestNG()
+    options.suites "src/e2e/resources/testng-axe.xml"
+    options.outputDirectory = file("${buildDir}/reports/axe-test")
+    options.useDefaultListeners = true
+    ignoreFailures = false
+    maxHeapSize = "1g"
+    reports.html.required = false
+    reports.junitXml.required = false
+    jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
+    testLogging {
+        events "passed"
+    }
+    afterTest afterTestClosure
+    afterSuite checkTestNgFailureClosure
 }
 
 // COVERAGE TASKS

--- a/src/e2e/java/teammates/e2e/cases/AdminNotificationsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AdminNotificationsPageE2ETest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.NotificationStyle;
@@ -88,12 +89,13 @@ public class AdminNotificationsPageE2ETest extends BaseE2ETestCase {
         notificationsPage.verifyStatusMessage("Notification has been deleted.");
         verifyAbsentInDatabase(newNotification);
 
-        ______TS("delete test notifications from database");
-        for (NotificationAttributes notification : notifications) {
-            notificationsPage.deleteNotification(notification);
-            verifyAbsentInDatabase(notification);
-        }
+    }
 
+    @AfterClass
+    public void classTeardown() {
+        for (NotificationAttributes notification : testData.notifications.values()) {
+            BACKDOOR.deleteNotification(notification.getNotificationId());
+        }
     }
 
 }

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -45,7 +45,11 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
 
     static final BackDoor BACKDOOR = BackDoor.getInstance();
 
-    DataBundle testData;
+    /**
+     * Data to be used in the test.
+     */
+    protected DataBundle testData;
+
     private Browser browser;
 
     @BeforeClass

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -43,7 +43,10 @@ import teammates.test.ThreadHelper;
  */
 public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
 
-    static final BackDoor BACKDOOR = BackDoor.getInstance();
+    /**
+     * Backdoor used to call APIs.
+     */
+    protected static final BackDoor BACKDOOR = BackDoor.getInstance();
 
     /**
      * Data to be used in the test.
@@ -299,7 +302,10 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getInstructor(instructor.getCourseId(), instructor.getEmail());
     }
 
-    String getKeyForInstructor(String courseId, String instructorEmail) {
+    /**
+     * Gets registration key for a given instructor.
+     */
+    protected String getKeyForInstructor(String courseId, String instructorEmail) {
         return getInstructor(courseId, instructorEmail).getKey();
     }
 
@@ -308,7 +314,10 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return BACKDOOR.getStudent(student.getCourse(), student.getEmail());
     }
 
-    String getKeyForStudent(StudentAttributes student) {
+    /**
+     * Gets registration key for a given student.
+     */
+    protected String getKeyForStudent(StudentAttributes student) {
         return getStudent(student).getKey();
     }
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorNotificationsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorNotificationsPageE2ETest.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -61,11 +62,13 @@ public class InstructorNotificationsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("notification banner is not visible");
         assertFalse(notificationsPage.isBannerVisible());
+    }
 
-        ______TS("delete test notifications from database");
+    @AfterClass
+    public void classTeardown() {
         for (NotificationAttributes notification : testData.notifications.values()) {
             BACKDOOR.deleteNotification(notification.getNotificationId());
-            verifyAbsentInDatabase(notification);
         }
     }
+
 }

--- a/src/e2e/java/teammates/e2e/cases/NotificationBannerE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationBannerE2ETest.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -58,10 +59,12 @@ public class NotificationBannerE2ETest extends BaseE2ETestCase {
         account.setReadNotifications(readNotifications);
         verifyPresentInDatabase(account);
 
-        ______TS("delete test notifications from database");
-        for (NotificationAttributes n : testData.notifications.values()) {
-            BACKDOOR.deleteNotification(n.getNotificationId());
-            verifyAbsentInDatabase(n);
+    }
+
+    @AfterClass
+    public void classTeardown() {
+        for (NotificationAttributes notification : testData.notifications.values()) {
+            BACKDOOR.deleteNotification(notification.getNotificationId());
         }
     }
 }

--- a/src/e2e/java/teammates/e2e/cases/StudentNotificationsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentNotificationsPageE2ETest.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -61,11 +62,13 @@ public class StudentNotificationsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("notification banner is not visible");
         assertFalse(notificationsPage.isBannerVisible());
+    }
 
-        ______TS("delete test notifications from database");
+    @AfterClass
+    public void classTeardown() {
         for (NotificationAttributes notification : testData.notifications.values()) {
             BACKDOOR.deleteNotification(notification.getNotificationId());
-            verifyAbsentInDatabase(notification);
         }
     }
+
 }

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminAccountsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminAccountsPageAxeTest.java
@@ -1,0 +1,38 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.AdminAccountsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#ADMIN_ACCOUNTS_PAGE}.
+ */
+public class AdminAccountsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/AdminAccountsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+
+        String googleId = "tm.e2e.AAccounts.instr2";
+
+        AppUrl accountsPageUrl = createFrontendUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
+                .withParam(Const.ParamsNames.INSTRUCTOR_ID, googleId);
+        AdminAccountsPage accountsPage = loginAdminToPage(accountsPageUrl, AdminAccountsPage.class);
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(accountsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminAccountsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminAccountsPageAxeTest.java
@@ -24,11 +24,8 @@ public class AdminAccountsPageAxeTest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-
-        String googleId = "tm.e2e.AAccounts.instr2";
-
         AppUrl accountsPageUrl = createFrontendUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
-                .withParam(Const.ParamsNames.INSTRUCTOR_ID, googleId);
+                .withParam(Const.ParamsNames.INSTRUCTOR_ID, "tm.e2e.AAccounts.instr2");
         AdminAccountsPage accountsPage = loginAdminToPage(accountsPageUrl, AdminAccountsPage.class);
 
         Results results = AxeUtil.AXE_BUILDER.analyze(accountsPage.getBrowser().getDriver());

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminHomePageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminHomePageAxeTest.java
@@ -1,0 +1,33 @@
+package teammates.e2e.cases.axe;
+
+import com.deque.html.axecore.results.Results;
+import org.testng.annotations.Test;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.AdminHomePage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#ADMIN_HOME_PAGE}.
+ */
+public class AdminHomePageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/AdminHomePageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_HOME_PAGE);
+        AdminHomePage homePage = loginAdminToPage(url, AdminHomePage.class);
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(homePage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminNotificationsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminNotificationsPageAxeTest.java
@@ -1,0 +1,34 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.AdminNotificationsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#ADMIN_NOTIFICATIONS_PAGE}.
+ */
+public class AdminNotificationsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/AdminNotificationsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_NOTIFICATIONS_PAGE);
+        AdminNotificationsPage notificationsPage = loginAdminToPage(url, AdminNotificationsPage.class);
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(notificationsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminSearchPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminSearchPageAxeTest.java
@@ -1,0 +1,51 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.AdminSearchPage;
+import teammates.e2e.util.AxeUtil;
+import teammates.e2e.util.TestProperties;
+
+/**
+ * SUT: {@link Const.WebPageURIs#ADMIN_SEARCH_PAGE}.
+ */
+public class AdminSearchPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        if (!TestProperties.INCLUDE_SEARCH_TESTS) {
+            return;
+        }
+
+        testData = loadDataBundle("/AdminSearchPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+        putDocuments(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        if (!TestProperties.INCLUDE_SEARCH_TESTS) {
+            return;
+        }
+
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_SEARCH_PAGE);
+        AdminSearchPage searchPage = loginAdminToPage(url, AdminSearchPage.class);
+
+        StudentAttributes student = testData.students.get("student1InCourse1");
+
+        String searchContent = student.getEmail();
+        searchPage.inputSearchContent(searchContent);
+        searchPage.clickSearchButton();
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(searchPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminSessionsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminSessionsPageAxeTest.java
@@ -1,0 +1,73 @@
+package teammates.e2e.cases.axe;
+
+import java.time.Instant;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.AdminSessionsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#ADMIN_SESSIONS_PAGE}.
+ */
+public class AdminSessionsPageAxeTest extends BaseE2ETestCase {
+    private FeedbackSessionAttributes openFeedbackSession;
+    private FeedbackSessionAttributes awaitingFeedbackSession;
+    private FeedbackSessionAttributes futureFeedbackSession;
+    private Instant instant3DaysAgo = TimeHelper.getInstantDaysOffsetFromNow(-3);
+    private Instant instantTomorrow = TimeHelper.getInstantDaysOffsetFromNow(1);
+    private Instant instant3DaysLater = TimeHelper.getInstantDaysOffsetFromNow(3);
+    private Instant instant10DaysLater = TimeHelper.getInstantDaysOffsetFromNow(10);
+    private Instant instant24DaysLater = TimeHelper.getInstantDaysOffsetFromNow(24);
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/AdminSessionsPageE2ETest.json");
+
+        // To guarantee that there will always be some "ongoing sessions" listed,
+        // the test data is injected with date/time values relative to the time where the test takes place
+
+        openFeedbackSession = testData.feedbackSessions.get("session1InCourse1");
+        openFeedbackSession.setStartTime(instant3DaysAgo);
+        openFeedbackSession.setCreatedTime(instant3DaysAgo);
+        openFeedbackSession.setSessionVisibleFromTime(instant3DaysAgo);
+        openFeedbackSession.setEndTime(instant3DaysLater);
+        openFeedbackSession.setResultsVisibleFromTime(instant3DaysLater);
+
+        awaitingFeedbackSession = testData.feedbackSessions.get("session2InCourse1");
+        awaitingFeedbackSession.setStartTime(instantTomorrow);
+        awaitingFeedbackSession.setCreatedTime(instant3DaysAgo);
+        awaitingFeedbackSession.setSessionVisibleFromTime(instantTomorrow);
+        awaitingFeedbackSession.setEndTime(instant3DaysLater);
+        awaitingFeedbackSession.setResultsVisibleFromTime(instant3DaysLater);
+
+        futureFeedbackSession = testData.feedbackSessions.get("session3InCourse1");
+        futureFeedbackSession.setStartTime(instant10DaysLater);
+        futureFeedbackSession.setCreatedTime(instant3DaysAgo);
+        futureFeedbackSession.setSessionVisibleFromTime(instant10DaysLater);
+        futureFeedbackSession.setEndTime(instant24DaysLater);
+        futureFeedbackSession.setResultsVisibleFromTime(instant24DaysLater);
+
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+
+        AppUrl sessionsUrl = createFrontendUrl(Const.WebPageURIs.ADMIN_SESSIONS_PAGE);
+        AdminSessionsPage sessionsPage = loginAdminToPage(sessionsUrl, AdminSessionsPage.class);
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(sessionsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/AdminSessionsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/AdminSessionsPageAxeTest.java
@@ -18,9 +18,6 @@ import teammates.e2e.util.AxeUtil;
  * SUT: {@link Const.WebPageURIs#ADMIN_SESSIONS_PAGE}.
  */
 public class AdminSessionsPageAxeTest extends BaseE2ETestCase {
-    private FeedbackSessionAttributes openFeedbackSession;
-    private FeedbackSessionAttributes awaitingFeedbackSession;
-    private FeedbackSessionAttributes futureFeedbackSession;
     private Instant instant3DaysAgo = TimeHelper.getInstantDaysOffsetFromNow(-3);
     private Instant instantTomorrow = TimeHelper.getInstantDaysOffsetFromNow(1);
     private Instant instant3DaysLater = TimeHelper.getInstantDaysOffsetFromNow(3);
@@ -34,21 +31,21 @@ public class AdminSessionsPageAxeTest extends BaseE2ETestCase {
         // To guarantee that there will always be some "ongoing sessions" listed,
         // the test data is injected with date/time values relative to the time where the test takes place
 
-        openFeedbackSession = testData.feedbackSessions.get("session1InCourse1");
+        FeedbackSessionAttributes openFeedbackSession = testData.feedbackSessions.get("session1InCourse1");
         openFeedbackSession.setStartTime(instant3DaysAgo);
         openFeedbackSession.setCreatedTime(instant3DaysAgo);
         openFeedbackSession.setSessionVisibleFromTime(instant3DaysAgo);
         openFeedbackSession.setEndTime(instant3DaysLater);
         openFeedbackSession.setResultsVisibleFromTime(instant3DaysLater);
 
-        awaitingFeedbackSession = testData.feedbackSessions.get("session2InCourse1");
+        FeedbackSessionAttributes awaitingFeedbackSession = testData.feedbackSessions.get("session2InCourse1");
         awaitingFeedbackSession.setStartTime(instantTomorrow);
         awaitingFeedbackSession.setCreatedTime(instant3DaysAgo);
         awaitingFeedbackSession.setSessionVisibleFromTime(instantTomorrow);
         awaitingFeedbackSession.setEndTime(instant3DaysLater);
         awaitingFeedbackSession.setResultsVisibleFromTime(instant3DaysLater);
 
-        futureFeedbackSession = testData.feedbackSessions.get("session3InCourse1");
+        FeedbackSessionAttributes futureFeedbackSession = testData.feedbackSessions.get("session3InCourse1");
         futureFeedbackSession.setStartTime(instant10DaysLater);
         futureFeedbackSession.setCreatedTime(instant3DaysAgo);
         futureFeedbackSession.setSessionVisibleFromTime(instant10DaysLater);
@@ -61,7 +58,6 @@ public class AdminSessionsPageAxeTest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-
         AppUrl sessionsUrl = createFrontendUrl(Const.WebPageURIs.ADMIN_SESSIONS_PAGE);
         AdminSessionsPage sessionsPage = loginAdminToPage(sessionsUrl, AdminSessionsPage.class);
 

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackResultsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackResultsPageAxeTest.java
@@ -1,0 +1,43 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.FeedbackResultsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#SESSION_RESULTS_PAGE}.
+ */
+public class FeedbackResultsPageAxeTest extends BaseE2ETestCase {
+    private FeedbackSessionAttributes openSession;
+    private StudentAttributes student;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/FeedbackResultsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+
+        student = testData.students.get("Alice");
+        openSession = testData.feedbackSessions.get("Open Session");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
+                .withCourseId(openSession.getCourseId())
+                .withSessionName(openSession.getFeedbackSessionName());
+        FeedbackResultsPage resultsPage = loginToPage(url, FeedbackResultsPage.class, student.getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(resultsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
@@ -17,7 +17,7 @@ public class FeedbackSubmitPageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadDataBundle("/FeedbackConstSumRecipientQuestionE2ETest.json");
+        testData = loadDataBundle("/FeedbackSubmitPageE2ETest.json");
         removeAndRestoreDataBundle(testData);
     }
 
@@ -25,11 +25,11 @@ public class FeedbackSubmitPageAxeTest extends BaseE2ETestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withCourseId(testData.courses.get("course").getId())
-                .withSessionName(testData.feedbackSessions.get("openSession").getFeedbackSessionName());
+                .withCourseId(testData.courses.get("FSubmit.CS2104").getId())
+                .withSessionName(testData.feedbackSessions.get("Open Session").getFeedbackSessionName());
 
         FeedbackSubmitPage feedbackSubmitPage = loginToPage(url, FeedbackSubmitPage.class,
-                testData.students.get("alice.tmms@FCSumRcptQn.CS2104").getGoogleId());
+                testData.students.get("Alice").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(feedbackSubmitPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
@@ -1,0 +1,43 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.FeedbackSubmitPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#STUDENT_SESSION_SUBMISSION_PAGE}.
+ */
+public class FeedbackSubmitPageAxeTest extends BaseE2ETestCase {
+    FeedbackSessionAttributes feedbackSession;
+    StudentAttributes student;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/FeedbackConstSumRecipientQuestionE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+
+        feedbackSession = testData.feedbackSessions.get("openSession");
+        student = testData.students.get("alice.tmms@FCSumRcptQn.CS2104");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
+                .withCourseId(student.getCourse())
+                .withSessionName(feedbackSession.getFeedbackSessionName());
+
+        FeedbackSubmitPage feedbackSubmitPage = loginToPage(url, FeedbackSubmitPage.class, student.getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(feedbackSubmitPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
@@ -4,8 +4,6 @@ import org.testng.annotations.Test;
 
 import com.deque.html.axecore.results.Results;
 
-import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
@@ -16,28 +14,25 @@ import teammates.e2e.util.AxeUtil;
  * SUT: {@link Const.WebPageURIs#STUDENT_SESSION_SUBMISSION_PAGE}.
  */
 public class FeedbackSubmitPageAxeTest extends BaseE2ETestCase {
-    FeedbackSessionAttributes feedbackSession;
-    StudentAttributes student;
 
     @Override
     protected void prepareTestData() {
         testData = loadDataBundle("/FeedbackConstSumRecipientQuestionE2ETest.json");
         removeAndRestoreDataBundle(testData);
-
-        feedbackSession = testData.feedbackSessions.get("openSession");
-        student = testData.students.get("alice.tmms@FCSumRcptQn.CS2104");
     }
 
     @Test
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withCourseId(student.getCourse())
-                .withSessionName(feedbackSession.getFeedbackSessionName());
+                .withCourseId(testData.courses.get("course").getId())
+                .withSessionName(testData.feedbackSessions.get("openSession").getFeedbackSessionName());
 
-        FeedbackSubmitPage feedbackSubmitPage = loginToPage(url, FeedbackSubmitPage.class, student.getGoogleId());
+        FeedbackSubmitPage feedbackSubmitPage = loginToPage(url, FeedbackSubmitPage.class,
+                testData.students.get("alice.tmms@FCSumRcptQn.CS2104").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(feedbackSubmitPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());
     }
+
 }

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseDetailsPageAxeTest.java
@@ -1,0 +1,53 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorCourseDetailsPage;
+import teammates.e2e.util.AxeUtil;
+import teammates.e2e.util.TestProperties;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_DETAILS_PAGE}.
+ */
+public class InstructorCourseDetailsPageAxeTest extends BaseE2ETestCase {
+    private StudentAttributes student;
+    private CourseAttributes course;
+
+    private String fileName;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCourseDetailsPageE2ETest.json");
+        student = testData.students.get("charlie.tmms@ICDet.CS2104");
+        student.setEmail(TestProperties.TEST_EMAIL);
+
+        removeAndRestoreDataBundle(testData);
+        course = testData.courses.get("ICDet.CS2104");
+        fileName = "/" + course.getId() + "_studentList.csv";
+    }
+
+    @BeforeClass
+    public void classSetup() {
+        deleteDownloadsFile(fileName);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl detailsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_DETAILS_PAGE)
+                .withCourseId(course.getId());
+        InstructorCourseDetailsPage detailsPage = loginToPage(detailsPageUrl, InstructorCourseDetailsPage.class,
+                testData.instructors.get("ICDet.instr").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(detailsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseDetailsPageAxeTest.java
@@ -1,53 +1,36 @@
 package teammates.e2e.cases.axe;
 
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.deque.html.axecore.results.Results;
 
-import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
 import teammates.e2e.pageobjects.InstructorCourseDetailsPage;
 import teammates.e2e.util.AxeUtil;
-import teammates.e2e.util.TestProperties;
 
 /**
  * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_DETAILS_PAGE}.
  */
 public class InstructorCourseDetailsPageAxeTest extends BaseE2ETestCase {
-    private StudentAttributes student;
-    private CourseAttributes course;
-
-    private String fileName;
 
     @Override
     protected void prepareTestData() {
         testData = loadDataBundle("/InstructorCourseDetailsPageE2ETest.json");
-        student = testData.students.get("charlie.tmms@ICDet.CS2104");
-        student.setEmail(TestProperties.TEST_EMAIL);
-
         removeAndRestoreDataBundle(testData);
-        course = testData.courses.get("ICDet.CS2104");
-        fileName = "/" + course.getId() + "_studentList.csv";
-    }
-
-    @BeforeClass
-    public void classSetup() {
-        deleteDownloadsFile(fileName);
     }
 
     @Test
     @Override
     public void testAll() {
         AppUrl detailsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_DETAILS_PAGE)
-                .withCourseId(course.getId());
+                .withCourseId(testData.courses.get("ICDet.CS2104").getId());
         InstructorCourseDetailsPage detailsPage = loginToPage(detailsPageUrl, InstructorCourseDetailsPage.class,
                 testData.instructors.get("ICDet.instr").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(detailsPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());
     }
+
 }

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEditPageAxeTest.java
@@ -1,0 +1,41 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorCourseEditPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_EDIT_PAGE}.
+ */
+public class InstructorCourseEditPageAxeTest extends BaseE2ETestCase {
+    CourseAttributes course;
+    InstructorAttributes instructor;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCourseEditPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+
+        course = testData.courses.get("ICEdit.CS2104");
+        instructor = testData.instructors.get("ICEdit.coowner.CS2104");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
+                .withCourseId(course.getId());
+        InstructorCourseEditPage editPage = loginToPage(url, InstructorCourseEditPage.class, instructor.getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(editPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEditPageAxeTest.java
@@ -4,8 +4,6 @@ import org.testng.annotations.Test;
 
 import com.deque.html.axecore.results.Results;
 
-import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
@@ -16,26 +14,23 @@ import teammates.e2e.util.AxeUtil;
  * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_EDIT_PAGE}.
  */
 public class InstructorCourseEditPageAxeTest extends BaseE2ETestCase {
-    CourseAttributes course;
-    InstructorAttributes instructor;
 
     @Override
     protected void prepareTestData() {
         testData = loadDataBundle("/InstructorCourseEditPageE2ETest.json");
         removeAndRestoreDataBundle(testData);
-
-        course = testData.courses.get("ICEdit.CS2104");
-        instructor = testData.instructors.get("ICEdit.coowner.CS2104");
     }
 
     @Test
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
-                .withCourseId(course.getId());
-        InstructorCourseEditPage editPage = loginToPage(url, InstructorCourseEditPage.class, instructor.getGoogleId());
+                .withCourseId(testData.courses.get("ICEdit.CS2104").getId());
+        InstructorCourseEditPage editPage = loginToPage(url, InstructorCourseEditPage.class,
+                testData.instructors.get("ICEdit.coowner.CS2104").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(editPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());
     }
+
 }

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEnrollPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEnrollPageAxeTest.java
@@ -1,0 +1,36 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorCourseEnrollPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_ENROLL_PAGE}.
+ */
+public class InstructorCourseEnrollPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCourseEnrollPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_ENROLL_PAGE)
+                .withCourseId(testData.courses.get("ICEnroll.CS2104").getId());
+        InstructorCourseEnrollPage enrollPage = loginToPage(url, InstructorCourseEnrollPage.class,
+                testData.instructors.get("ICEnroll.teammates.test").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(enrollPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseJoinConfirmationPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseJoinConfirmationPageAxeTest.java
@@ -1,0 +1,42 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.CourseJoinConfirmationPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#JOIN_PAGE}.
+ */
+public class InstructorCourseJoinConfirmationPageAxeTest extends BaseE2ETestCase {
+    InstructorAttributes newInstructor;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCourseJoinConfirmationPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+
+        newInstructor = testData.instructors.get("ICJoinConf.instr.CS1101");
+        newInstructor.setGoogleId("tm.e2e.ICJoinConf.instr2");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
+                .withRegistrationKey(getKeyForInstructor(testData.courses.get("ICJoinConf.CS1101").getId(),
+                        newInstructor.getEmail()))
+                .withEntityType(Const.EntityType.INSTRUCTOR);
+        CourseJoinConfirmationPage confirmationPage = loginToPage(
+                joinLink, CourseJoinConfirmationPage.class, newInstructor.getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(confirmationPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsEditPageAxeTest.java
@@ -1,0 +1,38 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorCourseStudentDetailsEditPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT_PAGE}.
+ */
+public class InstructorCourseStudentDetailsEditPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCourseStudentDetailsEditPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl editPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT_PAGE)
+                .withCourseId(testData.courses.get("ICSDetEdit.CS2104").getId())
+                .withStudentEmail(testData.students.get("ICSDetEdit.jose.tmms").getEmail());
+        InstructorCourseStudentDetailsEditPage editPage =
+                loginToPage(editPageUrl, InstructorCourseStudentDetailsEditPage.class,
+                testData.instructors.get("ICSDetEdit.instr").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(editPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsPageAxeTest.java
@@ -1,0 +1,38 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorCourseStudentDetailsViewPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE}.
+ */
+public class InstructorCourseStudentDetailsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCourseStudentDetailsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl viewPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE)
+                .withCourseId(testData.courses.get("ICSDet.CS2104").getId())
+                .withStudentEmail(testData.students.get("ICSDet.jose.tmms").getEmail());
+        InstructorCourseStudentDetailsViewPage viewPage =
+                loginToPage(viewPageUrl, InstructorCourseStudentDetailsViewPage.class,
+                testData.instructors.get("ICSDet.instr").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(viewPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCoursesPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCoursesPageAxeTest.java
@@ -1,0 +1,35 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorCoursesPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSES_PAGE}.
+ */
+public class InstructorCoursesPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorCoursesPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSES_PAGE);
+        InstructorCoursesPage coursesPage = loginToPage(url, InstructorCoursesPage.class,
+                testData.accounts.get("instructor").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(coursesPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
@@ -1,0 +1,46 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_EDIT_PAGE}.
+ */
+public class InstructorFeedbackEditPageAxeTest extends BaseE2ETestCase {
+    InstructorAttributes instructor;
+    CourseAttributes course;
+    FeedbackSessionAttributes feedbackSession;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/FeedbackConstSumRecipientQuestionE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+
+        instructor = testData.instructors.get("instructor");
+        course = testData.courses.get("course");
+        feedbackSession = testData.feedbackSessions.get("openSession");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
+                .withCourseId(course.getId())
+                .withSessionName(feedbackSession.getFeedbackSessionName());
+
+        InstructorFeedbackEditPage feedbackEditPage = loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(feedbackEditPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
@@ -4,9 +4,6 @@ import org.testng.annotations.Test;
 
 import com.deque.html.axecore.results.Results;
 
-import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
-import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
@@ -17,28 +14,22 @@ import teammates.e2e.util.AxeUtil;
  * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_EDIT_PAGE}.
  */
 public class InstructorFeedbackEditPageAxeTest extends BaseE2ETestCase {
-    InstructorAttributes instructor;
-    CourseAttributes course;
-    FeedbackSessionAttributes feedbackSession;
 
     @Override
     protected void prepareTestData() {
         testData = loadDataBundle("/FeedbackConstSumRecipientQuestionE2ETest.json");
         removeAndRestoreDataBundle(testData);
-
-        instructor = testData.instructors.get("instructor");
-        course = testData.courses.get("course");
-        feedbackSession = testData.feedbackSessions.get("openSession");
     }
 
     @Test
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
-                .withCourseId(course.getId())
-                .withSessionName(feedbackSession.getFeedbackSessionName());
+                .withCourseId(testData.courses.get("course").getId())
+                .withSessionName(testData.feedbackSessions.get("openSession").getFeedbackSessionName());
 
-        InstructorFeedbackEditPage feedbackEditPage = loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
+        InstructorFeedbackEditPage feedbackEditPage = loginToPage(url, InstructorFeedbackEditPage.class,
+                testData.instructors.get("instructor").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(feedbackEditPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
@@ -17,7 +17,7 @@ public class InstructorFeedbackEditPageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadDataBundle("/FeedbackConstSumRecipientQuestionE2ETest.json");
+        testData = loadDataBundle("/InstructorFeedbackEditPageE2ETest.json");
         removeAndRestoreDataBundle(testData);
     }
 

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageAxeTest.java
@@ -13,7 +13,7 @@ import teammates.e2e.util.AxeUtil;
 /**
  * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_REPORT_PAGE}.
  */
-public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
+public class InstructorFeedbackReportPageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageE2ETest.java
@@ -7,28 +7,28 @@ import com.deque.html.axecore.results.Results;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
-import teammates.e2e.pageobjects.FeedbackResultsPage;
+import teammates.e2e.pageobjects.InstructorFeedbackResultsPage;
 import teammates.e2e.util.AxeUtil;
 
 /**
- * SUT: {@link Const.WebPageURIs#SESSION_RESULTS_PAGE}.
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_REPORT_PAGE}.
  */
-public class FeedbackResultsPageAxeTest extends BaseE2ETestCase {
+public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadDataBundle("/FeedbackResultsPageE2ETest.json");
+        testData = loadDataBundle("/InstructorFeedbackReportPageE2ETest.json");
         removeAndRestoreDataBundle(testData);
     }
 
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
-                .withCourseId(testData.courses.get("FRes.CS2104").getId())
+        AppUrl resultsUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
+                .withCourseId(testData.courses.get("tm.e2e.IFRep.CS2104").getId())
                 .withSessionName(testData.feedbackSessions.get("Open Session").getFeedbackSessionName());
-        FeedbackResultsPage resultsPage = loginToPage(url, FeedbackResultsPage.class,
-                testData.students.get("Alice").getGoogleId());
+        InstructorFeedbackResultsPage resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class,
+                testData.instructors.get("tm.e2e.IFRep.instr").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(resultsPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackSessionsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackSessionsPageAxeTest.java
@@ -13,7 +13,7 @@ import teammates.e2e.util.AxeUtil;
 /**
  * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSIONS_PAGE}.
  */
-public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
+public class InstructorFeedbackSessionsPageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackSessionsPageE2ETest.java
@@ -1,0 +1,36 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorFeedbackSessionsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSIONS_PAGE}.
+ */
+public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorFeedbackSessionsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSIONS_PAGE);
+        InstructorFeedbackSessionsPage feedbackSessionsPage =
+                loginToPage(url, InstructorFeedbackSessionsPage.class,
+                testData.instructors.get("instructor").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(feedbackSessionsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorHomePageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorHomePageAxeTest.java
@@ -7,25 +7,26 @@ import com.deque.html.axecore.results.Results;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
-import teammates.e2e.pageobjects.AdminHomePage;
+import teammates.e2e.pageobjects.InstructorHomePage;
 import teammates.e2e.util.AxeUtil;
 
 /**
- * SUT: {@link Const.WebPageURIs#ADMIN_HOME_PAGE}.
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_HOME_PAGE}.
  */
-public class AdminHomePageAxeTest extends BaseE2ETestCase {
+public class InstructorHomePageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadDataBundle("/AdminHomePageE2ETest.json");
+        testData = loadDataBundle("/InstructorHomePageE2ETest.json");
         removeAndRestoreDataBundle(testData);
     }
 
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_HOME_PAGE);
-        AdminHomePage homePage = loginAdminToPage(url, AdminHomePage.class);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE);
+        InstructorHomePage homePage = loginToPage(url, InstructorHomePage.class,
+                testData.instructors.get("IHome.instr.CS2104").getGoogleId());
 
         Results results = AxeUtil.AXE_BUILDER.analyze(homePage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorNotificationsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorNotificationsPageAxeTest.java
@@ -1,0 +1,43 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorNotificationsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_NOTIFICATIONS_PAGE}.
+ */
+public class InstructorNotificationsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorNotificationsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl notificationsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_NOTIFICATIONS_PAGE);
+        InstructorNotificationsPage notificationsPage = loginToPage(notificationsPageUrl, InstructorNotificationsPage.class,
+                testData.accounts.get("INotifs.instr").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(notificationsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+    @AfterClass
+    public void classTeardown() {
+        for (NotificationAttributes notification : testData.notifications.values()) {
+            BACKDOOR.deleteNotification(notification.getNotificationId());
+        }
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorSearchPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorSearchPageAxeTest.java
@@ -14,7 +14,7 @@ import teammates.e2e.util.TestProperties;
 /**
  * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SEARCH_PAGE}.
  */
-public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
+public class InstructorSearchPageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorSearchPageE2ETest.java
@@ -7,14 +7,14 @@ import com.deque.html.axecore.results.Results;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
-import teammates.e2e.pageobjects.AdminSearchPage;
+import teammates.e2e.pageobjects.InstructorSearchPage;
 import teammates.e2e.util.AxeUtil;
 import teammates.e2e.util.TestProperties;
 
 /**
- * SUT: {@link Const.WebPageURIs#ADMIN_SEARCH_PAGE}.
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SEARCH_PAGE}.
  */
-public class AdminSearchPageAxeTest extends BaseE2ETestCase {
+public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
@@ -22,7 +22,7 @@ public class AdminSearchPageAxeTest extends BaseE2ETestCase {
             return;
         }
 
-        testData = loadDataBundle("/AdminSearchPageE2ETest.json");
+        testData = loadDataBundle("/InstructorSearchPageE2ETest.json");
         removeAndRestoreDataBundle(testData);
         putDocuments(testData);
     }
@@ -34,11 +34,12 @@ public class AdminSearchPageAxeTest extends BaseE2ETestCase {
             return;
         }
 
-        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_SEARCH_PAGE);
-        AdminSearchPage searchPage = loginAdminToPage(url, AdminSearchPage.class);
+        AppUrl searchPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SEARCH_PAGE);
 
-        searchPage.inputSearchContent(testData.students.get("student1InCourse1").getEmail());
-        searchPage.clickSearchButton();
+        InstructorSearchPage searchPage = loginToPage(searchPageUrl, InstructorSearchPage.class,
+                testData.accounts.get("instructor1OfCourse1").getGoogleId());
+
+        searchPage.search("student2");
 
         Results results = AxeUtil.AXE_BUILDER.analyze(searchPage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorSessionIndividualExtensionPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorSessionIndividualExtensionPageAxeTest.java
@@ -1,0 +1,39 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorSessionIndividualExtensionPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_INDIVIDUAL_EXTENSION_PAGE}.
+ */
+public class InstructorSessionIndividualExtensionPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorSessionIndividualExtensionPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_INDIVIDUAL_EXTENSION_PAGE)
+                .withCourseId(testData.courses.get("course").getId())
+                .withSessionName(testData.feedbackSessions.get("firstSession").getFeedbackSessionName());
+
+        InstructorSessionIndividualExtensionPage individualExtensionPage =
+                loginToPage(url, InstructorSessionIndividualExtensionPage.class,
+                testData.instructors.get("ISesIe.instructor1").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(individualExtensionPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentActivityLogsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentActivityLogsPageAxeTest.java
@@ -1,0 +1,36 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorStudentActivityLogsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_STUDENT_ACTIVITY_LOGS_PAGE}.
+ */
+public class InstructorStudentActivityLogsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorStudentActivityLogsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_ACTIVITY_LOGS_PAGE)
+                .withCourseId("tm.e2e.ISActLogs.CS2104");
+        InstructorStudentActivityLogsPage studentActivityLogsPage =
+                loginToPage(url, InstructorStudentActivityLogsPage.class,
+                testData.instructors.get("instructor").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(studentActivityLogsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentListPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentListPageAxeTest.java
@@ -1,0 +1,35 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorStudentListPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_STUDENT_LIST_PAGE}.
+ */
+public class InstructorStudentListPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorStudentListPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl listPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_LIST_PAGE);
+        InstructorStudentListPage listPage = loginToPage(listPageUrl, InstructorStudentListPage.class,
+                testData.instructors.get("instructorOfCourse1").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(listPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentRecordsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentRecordsPageAxeTest.java
@@ -1,0 +1,39 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.InstructorStudentRecordsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_STUDENT_RECORDS_PAGE}.
+ */
+public class InstructorStudentRecordsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/InstructorStudentRecordsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl recordsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_RECORDS_PAGE)
+                .withCourseId(testData.courses.get("CS2104").getId())
+                .withStudentEmail(testData.students.get("benny.c.tmms@ISR.CS2104").getEmail());
+
+        InstructorStudentRecordsPage recordsPage =
+                loginToPage(recordsPageUrl, InstructorStudentRecordsPage.class,
+                testData.instructors.get("teammates.test.CS2104").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(recordsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentCourseDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentCourseDetailsPageAxeTest.java
@@ -1,0 +1,36 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.StudentCourseDetailsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#STUDENT_COURSE_DETAILS_PAGE}.
+ */
+public class StudentCourseDetailsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/StudentCourseDetailsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_COURSE_DETAILS_PAGE)
+                .withCourseId("tm.e2e.SCDet.CS2104");
+        StudentCourseDetailsPage detailsPage = loginToPage(url, StudentCourseDetailsPage.class,
+                testData.students.get("SCDet.alice").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(detailsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentCourseJoinConfirmationPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentCourseJoinConfirmationPageAxeTest.java
@@ -1,0 +1,42 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.CourseJoinConfirmationPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#JOIN_PAGE}.
+ */
+public class StudentCourseJoinConfirmationPageAxeTest extends BaseE2ETestCase {
+    private StudentAttributes newStudent;
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/StudentCourseJoinConfirmationPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+
+        newStudent = testData.students.get("alice.tmms@SCJoinConf.CS2104");
+        newStudent.setGoogleId(testData.accounts.get("alice.tmms").getGoogleId());
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
+                .withRegistrationKey(getKeyForStudent(newStudent))
+                .withCourseId(testData.courses.get("SCJoinConf.CS2104").getId())
+                .withEntityType(Const.EntityType.STUDENT);
+        CourseJoinConfirmationPage confirmationPage = loginToPage(
+                joinLink, CourseJoinConfirmationPage.class, newStudent.getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(confirmationPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentHomePageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentHomePageAxeTest.java
@@ -7,25 +7,26 @@ import com.deque.html.axecore.results.Results;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.cases.BaseE2ETestCase;
-import teammates.e2e.pageobjects.AdminHomePage;
+import teammates.e2e.pageobjects.StudentHomePage;
 import teammates.e2e.util.AxeUtil;
 
 /**
- * SUT: {@link Const.WebPageURIs#ADMIN_HOME_PAGE}.
+ * SUT: {@link Const.WebPageURIs#STUDENT_HOME_PAGE}.
  */
-public class AdminHomePageAxeTest extends BaseE2ETestCase {
+public class StudentHomePageAxeTest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadDataBundle("/AdminHomePageE2ETest.json");
+        testData = loadDataBundle("/StudentHomePageE2ETest.json");
         removeAndRestoreDataBundle(testData);
     }
 
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_HOME_PAGE);
-        AdminHomePage homePage = loginAdminToPage(url, AdminHomePage.class);
+
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
+        StudentHomePage homePage = loginToPage(url, StudentHomePage.class, "tm.e2e.SHome.student");
 
         Results results = AxeUtil.AXE_BUILDER.analyze(homePage.getBrowser().getDriver());
         assertTrue(AxeUtil.formatViolations(results), results.violationFree());

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentNotificationsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentNotificationsPageAxeTest.java
@@ -1,0 +1,43 @@
+package teammates.e2e.cases.axe;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import com.deque.html.axecore.results.Results;
+
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.cases.BaseE2ETestCase;
+import teammates.e2e.pageobjects.StudentNotificationsPage;
+import teammates.e2e.util.AxeUtil;
+
+/**
+ * SUT: {@link Const.WebPageURIs#STUDENT_NOTIFICATIONS_PAGE}.
+ */
+public class StudentNotificationsPageAxeTest extends BaseE2ETestCase {
+
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/StudentNotificationsPageE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        AppUrl notificationsPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_NOTIFICATIONS_PAGE);
+        StudentNotificationsPage notificationsPage = loginToPage(notificationsPageUrl, StudentNotificationsPage.class,
+                testData.accounts.get("SNotifs.student").getGoogleId());
+
+        Results results = AxeUtil.AXE_BUILDER.analyze(notificationsPage.getBrowser().getDriver());
+        assertTrue(AxeUtil.formatViolations(results), results.violationFree());
+    }
+
+    @AfterClass
+    public void classTeardown() {
+        for (NotificationAttributes notification : testData.notifications.values()) {
+            BACKDOOR.deleteNotification(notification.getNotificationId());
+        }
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/axe/package-info.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains accessibility test cases.
+ */
+package teammates.e2e.cases.axe;

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -115,6 +115,10 @@ public abstract class AppPage {
         throw new IllegalStateException("Not in the correct page!");
     }
 
+    public Browser getBrowser() {
+        return browser;
+    }
+
     /**
      * Gets a new page object representation of the currently open web page in the browser.
      *

--- a/src/e2e/java/teammates/e2e/pageobjects/Browser.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/Browser.java
@@ -56,6 +56,10 @@ public class Browser {
         this.driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(TestProperties.TEST_TIMEOUT));
     }
 
+    public WebDriver getDriver() {
+        return driver;
+    }
+
     public void addCookie(String name, String value, boolean isSecure, boolean isHttpOnly) {
         Cookie cookie = new Cookie.Builder(name, value)
                 .isSecure(isSecure)

--- a/src/e2e/java/teammates/e2e/util/AxeUtil.java
+++ b/src/e2e/java/teammates/e2e/util/AxeUtil.java
@@ -1,0 +1,47 @@
+package teammates.e2e.util;
+
+import com.deque.html.axecore.results.CheckedNode;
+import com.deque.html.axecore.results.Results;
+import com.deque.html.axecore.results.Rule;
+import com.deque.html.axecore.selenium.AxeBuilder;
+
+/**
+ * Utility class for accessibility tests.
+ */
+public final class AxeUtil {
+
+    /**
+     * Builder for accessibility tests.
+     */
+    public static final AxeBuilder AXE_BUILDER = new AxeBuilder();
+
+    private AxeUtil() {
+        // Utility class
+    }
+
+    static {
+        // Disable checking of colour contrast
+        AXE_BUILDER.setOptions("{ \"rules\": { \"color-contrast\": { \"enabled\": false } } }");
+    }
+
+    /**
+     * Formats accessibility violations into a readable string.
+     */
+    public static String formatViolations(Results results) {
+        int ruleCounter = 1;
+        StringBuilder builder = new StringBuilder(500);
+        for (Rule rule : results.getViolations()) {
+            int nodeCounter = 1;
+            builder.append(ruleCounter).append(". ").append(rule.getId()).append(" - ").append(rule.getDescription())
+                    .append(" (").append(rule.getHelpUrl()).append(")\n");
+            for (CheckedNode checkedNode : rule.getNodes()) {
+                builder.append(ruleCounter).append('.').append(nodeCounter).append(". ")
+                        .append(checkedNode.getTarget()).append('\n')
+                        .append(checkedNode.getFailureSummary()).append('\n');
+                nodeCounter++;
+            }
+            ruleCounter++;
+        }
+        return builder.toString();
+    }
+}

--- a/src/e2e/java/teammates/e2e/util/TestNgXmlTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestNgXmlTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.testng.annotations.Test;
 
@@ -22,7 +23,13 @@ public class TestNgXmlTest extends BaseTestCase {
         // <class name, package name>
         Map<String, String> testFiles = getTestFiles(testNgXml, "./src/e2e/java/teammates/e2e");
 
-        testFiles.forEach((key, value) -> assertTrue(isTestFileIncluded(testNgXml, value, key)));
+        testFiles.forEach((key, value) -> {
+            if (Objects.equals(value, "teammates.e2e.cases.axe")) {
+                // Exclude accessibility tests
+                return;
+            }
+            assertTrue(isTestFileIncluded(testNgXml, value, key));
+        });
     }
 
     /**

--- a/src/e2e/resources/testng-axe.xml
+++ b/src/e2e/resources/testng-axe.xml
@@ -12,7 +12,25 @@
             <class name="teammates.e2e.cases.axe.FeedbackSubmitPageAxeTest" />
             <class name="teammates.e2e.cases.axe.InstructorCourseDetailsPageAxeTest" />
             <class name="teammates.e2e.cases.axe.InstructorCourseEditPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCourseEnrollPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCourseJoinConfirmationPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCoursesPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCourseStudentDetailsEditPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCourseStudentDetailsPageAxeTest" />
             <class name="teammates.e2e.cases.axe.InstructorFeedbackEditPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorFeedbackReportPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorFeedbackSessionsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorHomePageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorNotificationsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorSearchPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorSessionIndividualExtensionPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorStudentActivityLogsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorStudentListPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorStudentRecordsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.StudentCourseDetailsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.StudentCourseJoinConfirmationPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.StudentHomePageAxeTest" />
+            <class name="teammates.e2e.cases.axe.StudentNotificationsPageAxeTest" />
         </classes>
     </test>
 </suite>

--- a/src/e2e/resources/testng-axe.xml
+++ b/src/e2e/resources/testng-axe.xml
@@ -2,11 +2,17 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="axe-tests" parallel="tests" thread-count="2">
     <test name="axe-tests" parallel="classes">
-        <packages>
-            <package name="teammates.e2e.util" />
-        </packages>
         <classes>
             <class name="teammates.e2e.cases.axe.AdminAccountsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.AdminHomePageAxeTest" />
+            <class name="teammates.e2e.cases.axe.AdminNotificationsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.AdminSearchPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.AdminSessionsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.FeedbackResultsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.FeedbackSubmitPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCourseDetailsPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorCourseEditPageAxeTest" />
+            <class name="teammates.e2e.cases.axe.InstructorFeedbackEditPageAxeTest" />
         </classes>
     </test>
 </suite>

--- a/src/e2e/resources/testng-axe.xml
+++ b/src/e2e/resources/testng-axe.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="axe-tests" parallel="tests" thread-count="2">
+    <test name="axe-tests" parallel="classes">
+        <packages>
+            <package name="teammates.e2e.util" />
+        </packages>
+        <classes>
+            <class name="teammates.e2e.cases.axe.AdminAccountsPageAxeTest" />
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Test PR for accessibility tests.

- Adds accessibility test workflow. Current plan is to make it an optional test, it will likely fail for most PRs until we fix most of them.
- Adds accessibility tests (still WIP). Put them under the E2E test package since they share page objects.
- Exposes the browser and driver in the page objects, as the driver is needed for accessibility analysis.